### PR TITLE
Fix sphinx doc URL

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -73,7 +73,7 @@ intersphinx_mapping = {
     "https://numpy.org/doc/stable/": None,
     "https://mirgecom.readthedocs.io/en/latest/": None,
     "https://documen.tician.de/pymbolic": None,
-    "cantera": ("https://cantera.org/documentation/docs-2.4/sphinx/html/", None),
+    "cantera": ("https://cantera.org/documentation/dev/sphinx/html", None),
     }
 
 autoclass_content = "class"


### PR DESCRIPTION
Addresses CI failures like this:
```
 WARNING: failed to reach any of the inventories with the following issues:
intersphinx inventory 'https://cantera.org/documentation/docs-2.4/sphinx/html/objects.inv' not fetchable due to <class 'requests.exceptions.HTTPError'>: 404 Client Error: Not Found for url: https://cantera.org/documentation/docs-2.4/sphinx/html/objects.inv
```