### PR TITLE
Paper Examples and Concentrations Array

### DIFF
--- a/examples/autoignition.py
+++ b/examples/autoignition.py
@@ -1,0 +1,110 @@
+import cantera as ct
+import pyrometheus as pyro
+from pyro_jax import *
+from functools import partial
+from jax import jit
+from jax import jacfwd
+
+
+def newton(fun, jac, y, *args, num_it=10, tol=1e-6):
+    """Newton method"""
+    for it in range(num_it):    
+        dy = jnp.linalg.solve(jac(y, *args), fun(y, *args))
+        y -= dy
+        if jnp.linalg.norm(dy) < tol:
+            return y
+
+
+def run_autoignition():
+
+    # Cantera solution object
+    sol = ct.Solution('../test/mechs/uconn32.yaml')
+
+    # Pyrometheus-generated code
+    pyro_class = pyro.codegen.python.get_thermochem_class(sol)
+    pyro_gas = make_jax_pyro_class(pyro_class, jnp)
+
+    # Thermodynamic conditions
+    pressure = pyro_gas.one_atm
+    temperature = 1250
+
+    # mass ratios
+    equiv_ratio = 1.0
+    ox_di_ratio = 0.21
+    stoich_ratio = 3
+    # indices
+    i_fu = pyro_gas.species_index("C2H4")
+    i_ox = pyro_gas.species_index("O2")
+    i_di = pyro_gas.species_index("N2")
+    # mole fractions
+    x = np.zeros(pyro_gas.num_species)
+    x[i_fu] = (ox_di_ratio*equiv_ratio)/(stoich_ratio+ox_di_ratio*equiv_ratio)
+    x[i_ox] = stoich_ratio*x[i_fu]/equiv_ratio
+    x[i_di] = (1.0-ox_di_ratio)*x[i_ox]/ox_di_ratio
+    # mass fractions
+    mass_fractions = jnp.array(x * pyro_gas.wts / sum(x*pyro_gas.wts),
+                               dtype=jnp.float64)
+    # internal energy
+    energy = pyro_gas.get_mixture_internal_energy_mass(temperature, mass_fractions)
+    # density
+    density = pyro_gas.get_density(pressure, temperature, mass_fractions)
+
+    # JIT-compiled functions
+    @jit
+    def get_temperature(mass_fractions):
+        return pyro_gas.get_temperature_energy(mass_fractions, energy, guess_temp)
+
+    @jit
+    def get_pressure(mass_fractions, temperature):
+        return pyro_gas.get_pressure(density, temperature, mass_fractions)
+
+    @jit
+    def chemical_source_term(mass_fractions):
+        temperature = pyro_gas.get_temperature_energy(mass_fractions, energy,
+                                                   guess_temp)
+        return pyro_gas.wts * pyro_gas.get_net_production_rates(density, temperature,
+                                                          mass_fractions) / density
+
+    chemical_jacobian = jit(jacfwd(chemical_source_term))
+
+    crank_nicolson_rhs = lambda y, y_prev, dt : y - y_prev - 0.5 * dt * (
+        chemical_source_term(y) + chemical_source_term(y_prev))
+        
+    crank_nicolson_jac = jit(jacfwd(crank_nicolson_rhs))
+
+    # Crank-Nicolson time-stepping
+    y = mass_fractions
+    guess_temp = temperature
+    dt = 1e-7
+    time = 0
+    final_time = 1e-3
+
+    history = jnp.array([time, guess_temp,
+                         y[pyro_gas.species_index('C2H4')],
+                         y[pyro_gas.species_index('CO2')],
+                         y[pyro_gas.species_index('H')],
+                         y[pyro_gas.species_index('CH3')]])
+    
+    print('t = %.4e [s], T = %.f [K]' % (time, guess_temp))        
+    
+    while time < final_time:
+        y_prev = y
+        y = newton(crank_nicolson_rhs, crank_nicolson_jac, y, y_prev, dt)
+        guess_temp = get_temperature(y)
+        time += dt
+        if not int(time/dt)%10:
+            history = np.vstack((history, [time, guess_temp,
+                                           y[pyro_gas.species_index('C2H4')],
+                                           y[pyro_gas.species_index('CO2')],
+                                           y[pyro_gas.species_index('H')],
+                                           y[pyro_gas.species_index('CH3')]]))
+        if not int(time/dt)%100:
+            print('t = %.4e [s], T = %.3f [K]' % (time, guess_temp))
+    
+    return    
+
+
+if __name__ == "__main__":
+
+    run_autoignition()
+    exit

--- a/examples/pyro_jax.py
+++ b/examples/pyro_jax.py
@@ -1,0 +1,90 @@
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+
+jax.config.update("jax_enable_x64", 1)
+
+
+def make_jax_pyro_class(pyro_class, usr_np):
+    if usr_np != jnp:
+        return pyro_class(usr_np)
+
+    class pyro_jax_numpy(pyro_class):
+
+        def _pyro_make_array(self, res_list):
+            """This works around (e.g.) numpy.exp not working with object arrays of numpy
+            scalars. It defaults to making object arrays, however if an array
+            consists of all scalars, it makes a "plain old" :class:`numpy.ndarray`.
+
+            See ``this numpy bug <https://github.com/numpy/numpy/issues/18004>`__
+            for more context.
+            """
+
+            from numbers import Number
+            # Needed to play nicely with Jax, which frequently creates
+            # arrays of shape () when handed numbers
+            all_numbers = all(
+                isinstance(e, Number)
+                or (isinstance(e, self.usr_np.ndarray) and e.shape == ())
+                for e in res_list)
+
+            if all_numbers:
+                return self.usr_np.array(res_list, dtype=self.usr_np.float64)
+
+#             result = self.usr_np.empty_like(res_list, dtype=object,
+#                                             shape=(len(res_list),))
+            result = self._pyro_zeros_like(self.usr_np.array(res_list))
+
+            # 'result[:] = res_list' may look tempting, however:
+            # https://github.com/numpy/numpy/issues/16564
+            for idx in range(len(res_list)):
+                result = result.at[idx].set(res_list[idx])
+
+            return result
+
+        def _pyro_norm(self, argument, normord):
+            """This works around numpy.linalg norm not working with scalars.
+
+            If the argument is a regular ole number, it uses :func:`numpy.abs`,
+            otherwise it uses ``usr_np.linalg.norm``.
+            """
+            # Wrap norm for scalars
+            from numbers import Number
+            if isinstance(argument, Number):
+                return self.usr_np.abs(argument)
+            # Needed to play nicely with Jax, which frequently creates
+            # arrays of shape () when handed numbers
+            if isinstance(argument, self.usr_np.ndarray) and argument.shape == ():
+                return self.usr_np.abs(argument)
+            return self.usr_np.linalg.norm(argument, normord)
+        
+        def get_temperature_enthalpy(self, mass_fractions, enthalpy, temp_init):
+
+            def cond_fun(temperature):
+                f = enthalpy - self.get_mixture_enthalpy_mass(temperature, mass_fractions)
+                j = -self.get_mixture_specific_heat_cp_mass(temperature, mass_fractions)
+                return abs(f/j) > 1e-5
+
+            def body_fun(temperature):
+                f = enthalpy - self.get_mixture_enthalpy_mass(temperature, mass_fractions)
+                j = -self.get_mixture_specific_heat_cp_mass(temperature, mass_fractions)
+                return temperature - f/j
+
+            return jax.lax.while_loop(cond_fun, body_fun, temp_init)
+        
+        def get_temperature_energy(self, mass_fractions, energy, temp_init):
+
+            def cond_fun(temperature):
+                f = energy - self.get_mixture_internal_energy_mass(temperature, mass_fractions)
+                j = -self.get_mixture_specific_heat_cv_mass(temperature, mass_fractions)
+                return abs(f/j) > 1e-5
+
+            def body_fun(temperature):
+                f = energy - self.get_mixture_internal_energy_mass(temperature, mass_fractions)
+                j = -self.get_mixture_specific_heat_cv_mass(temperature, mass_fractions)
+                return temperature - f/j
+
+            return jax.lax.while_loop(cond_fun, body_fun, temp_init)
+
+    return pyro_jax_numpy(usr_np=usr_np)

--- a/examples/steady_flamelet.py
+++ b/examples/steady_flamelet.py
@@ -1,0 +1,265 @@
+import cantera as ct
+import pyrometheus as pyro
+from pyro_jax import *
+from functools import partial
+from jax import jit
+from jax import jacfwd
+from itertools import product
+from scipy.special import erfcinv as erfc_inv
+
+
+def convert_mole_to_mass_fractions(x: jnp.array, wts: jnp.array):
+    return jnp.array(x * wts / sum(x*wts), dtype=jnp.float64)
+
+
+def stoichiometric_mixture_fraction(wts_elem, elem_matrix, y_ox, y_fu):
+    # Bilger weights    
+    bilger_weights = np.array([0.5/wts_elem[0], -1/wts_elem[1], 0])    
+    # Coupling functions
+    beta_ox = bilger_weights.dot(elem_matrix.dot(y_ox))
+    beta_fu = bilger_weights.dot(elem_matrix.dot(y_fu))
+    return -beta_ox/(beta_fu - beta_ox)
+
+
+def dissipation_rate_profile(z): 
+    return jnp.exp(-2*erfc_inv(2*z)**2)
+
+
+def newton(fun, jac, num_vars, num_points, q, *args, num_it=10, tol=1e-6, tag='', verbosity=0):
+    for it in range(num_it):        
+        dq = jnp.reshape(jnp.linalg.solve(
+            jnp.reshape(jac(q, *args), 
+                        (num_vars*num_points, num_vars*num_points)), 
+            fun(q, *args).ravel()), (num_vars, num_points))
+        q -= dq
+        if verbosity:
+            print(tag + "Newton: it = %i, err = %.4e" % (it, jnp.linalg.norm(dq)))
+        if jnp.linalg.norm(dq) < tol:
+            return q
+
+
+def crank_nicolson(fun, jac, num_vars, num_points, q, dt, num_steps, newton_it=10, newton_tol=1e-6, verbosity=0):
+    
+    step = 0
+    time = 0
+    # history = jnp.array([time, guess_temp, y[pyro_gas.species_index('H')]])
+    
+    print("Chirometheus: Crank-Nicolson: t = %.4e [s], T_max = %.3f [K]" % (time, q[0].max()))
+    
+    while step < num_steps:
+        q_prev = q
+        q = newton(fun, jac, num_vars, num_points, q, q_prev, dt, 
+                   num_it=newton_it, tol=newton_tol, tag="Chirometheus: Crank-Nicolson:", 
+                   verbosity=verbosity)
+        step += 1
+        time += dt
+        print("Chirhometues: Crank-Nicolson: t = %.4e [s], T_max = %.3f [K]" % (time, q[0].max()))
+    return q        
+        
+
+def steady_flamelet():
+
+    print("Chirometheus: solve for steady flamelets")
+    
+    # Cantera solution object (and elemental weights, matrix)
+    sol = ct.Solution("~/Packages/pyrometheus/test/mechs/sandiego.yaml")
+    
+    wts_s = jnp.array(sol.molecular_weights)
+    wts_e = jnp.array([wts_s[sol.species_index('H')], wts_s[sol.species_index('O')],
+                       wts_s[sol.species_index('N2')]/2])
+    elem_matrix = jnp.zeros([sol.n_elements, sol.n_species])
+    for e, s in product(range(sol.n_elements), range(sol.n_species)):
+        elem_matrix = elem_matrix.at[e, s].set(sol.n_atoms(s, e)*wts_e[e]/wts_s[s])
+
+    # Pyrometheus-generated code
+    pyro_code = pyro.codegen.python.gen_thermochem_code(sol)
+    pyro_class = pyro.codegen.python.get_thermochem_class(sol)
+    pyro_gas = make_jax_pyro_class(pyro_class, jnp)
+
+    """This next block sets the pressure and boundary conditions for
+    the flamelet calculation."""
+    num_vars = pyro_gas.num_species + 1
+    pressure = pyro_gas.one_atm
+
+    temp_ox = 500
+    temp_fu = 300
+    
+    x_ox = jnp.zeros(pyro_gas.num_species)
+    x_ox = x_ox.at[pyro_gas.species_index('O2')].set(0.21)
+    x_ox = x_ox.at[pyro_gas.species_index('N2')].set(0.79)
+    y_ox = convert_mole_to_mass_fractions(x_ox, pyro_gas.wts)
+    h_ox = pyro_gas.get_mixture_enthalpy_mass(temp_ox, y_ox)
+    
+    
+    x_fu = jnp.zeros(pyro_gas.num_species)
+    x_fu = x_fu.at[pyro_gas.species_index('H2')].set(0.5)
+    x_fu = x_fu.at[pyro_gas.species_index('N2')].set(0.5)
+    y_fu = convert_mole_to_mass_fractions(x_fu, pyro_gas.wts)
+    h_fu = pyro_gas.get_mixture_enthalpy_mass(temp_fu, y_fu)
+    
+    z_st = stoichiometric_mixture_fraction(wts_e, elem_matrix, y_ox, y_fu)
+    print("Chirometheus: stoich mixture fraction: Z_st = %.4f" % z_st)
+    print("Chirometheus: pressure: p = %.4e" % pressure)
+    print("Chirometheus: air stream temperature: T_ox = %.4f [K]" % temp_ox)
+    print("Chirometheus: fuel stream temperature: T_fu = %.4f [K]" % temp_fu)
+
+    # Grid and dissipation rate (chi) profile
+    num_points = 101
+
+    mixture_fraction = jnp.linspace(0, 1, num_points)
+    dz = 1/(num_points-1)
+
+    chi_st = 1000
+    diss_rate = chi_st * dissipation_rate_profile(mixture_fraction)/dissipation_rate_profile(z_st)
+    print("Chirometheus: stoich dissipation rate: chi_st = %.4f [1/s]" % chi_st)
+
+    # Initial profiles (equilibrium)
+    mass_fractions = (y_ox + (y_fu - y_ox)*mixture_fraction[:, None]).T
+    temperature = temp_ox + (temp_fu - temp_ox)*mixture_fraction
+    
+    for i in range(0, num_points):
+        y = y_ox + (y_fu - y_ox)*mixture_fraction[i]
+        h = h_ox + (h_fu - h_ox)*mixture_fraction[i]
+        sol.HPY = h, pressure, y
+        sol.equilibrate('HP')
+        mass_fractions = mass_fractions.at[:, i].set(jnp.array(sol.Y))
+        temperature = temperature.at[i].set(sol.T)
+
+    state = jnp.vstack((temperature, mass_fractions))
+
+    """This next block implements functions that are to be JIT-compiled.
+    These include finite differences, the steady-flamelet RHS, and
+    Crank-Nicolson with """
+    @jit
+    def first_deriv(f):
+        return jnp.hstack((
+            ((f[:, 1] - f[:, 0])/dz)[:, None], 
+            0.5*(f[:, 2:] - f[:, :-2])/dz, 
+            ((f[:, -1] - f[:, -2])/dz)[:, None]
+        ))
+
+    @jit
+    def second_deriv(f):    
+        return jnp.hstack((
+            ((f[:, 2] - 2*f[:, 1] + f[:, 0])/(dz**2))[:, None], 
+            (f[:, 2:] - 2*f[:, 1:-1] + f[:, :-2])/(dz**2), 
+            ((f[:, -1] - 2*f[:, -2] + f[:, -3])/(dz**2))[:, None]
+        ))
+
+    laplacian = jit(jacfwd(second_deriv))
+
+    @jit
+    def get_density(state):
+        return pyro_gas.get_density(pressure, state[0], state[1:])
+    
+    @jit
+    def get_internal_energy(state):
+        return pyro_gas.get_mixture_internal_energy_mass(state[0], state[1:])
+    
+    @jit
+    def get_mixture_specific_heat_cp_mass(state):
+        return pyro_gas.get_mixture_specific_heat_cp_mass(state[0], state[1:])
+    
+    @jit
+    def chemical_source_term(state):
+        density = get_density(state)
+        return pyro_gas.wts[:, None] * pyro_gas.get_net_production_rates(density, state[0], state[1:])
+    
+    chemical_jacobian = jit(jacfwd(chemical_source_term))
+    
+    @jit
+    def heat_release(state):
+        cp_mix = get_mixture_specific_heat_cp_mass(state)
+        h_species = pyro_gas.iwts[:, None] * pyro_gas.get_species_enthalpies_rt(state[0]) * \
+            pyro_gas.gas_constant * state[0]
+        m_dot = chemical_source_term(state)
+        return -jnp.sum(m_dot * h_species, axis=0) / cp_mix
+    
+    @jit
+    def flux(state):
+        # Mixture thermochemistry
+        density = get_density(state)
+        cp_mix = get_mixture_specific_heat_cp_mass(state)
+        # Species thermochemistry
+        h_species = pyro_gas.iwts[:, None] * pyro_gas.get_species_enthalpies_rt(state[0]) * \
+            pyro_gas.gas_constant * temperature
+        cp_species = pyro_gas.iwts[:, None] * pyro_gas.get_species_specific_heats_r(temperature) * \
+            pyro_gas.gas_constant
+        # Flux
+        return 0.5*(diss_rate*density/cp_mix) * first_deriv(state[0][None, :]) * (
+            first_deriv(cp_mix[None, :]) + 
+            jnp.sum(first_deriv(state[1:]) * cp_species, axis=0))
+    
+    @jit
+    def steady_flamelet_rhs(state):
+        density = get_density(state)
+        m_dot = chemical_source_term(state)
+        rhs = 0.5 * diss_rate * density * second_deriv(state) + jnp.vstack(
+            (heat_release(state), m_dot)) + jnp.vstack((flux(state), jnp.zeros_like(m_dot)))
+        return jnp.hstack((
+            (state[:, 0] - jnp.hstack((temp_ox, y_ox))).reshape((num_vars, 1)), 
+            rhs[:, 1:-1]/density[1:-1],
+            (state[:, -1] - jnp.hstack((temp_fu, y_fu))).reshape((num_vars, 1))
+        ))
+    
+    steady_flamelet_jac = jit(jacfwd(steady_flamelet_rhs))
+    
+    @jit
+    def crank_nicolson_rhs(q, q_prev, dt): 
+        return q - q_prev - 0.5 * dt * jnp.hstack(
+            (jnp.zeros((num_vars, 1)), 
+             (steady_flamelet_rhs(q) + 
+              steady_flamelet_rhs(q_prev))[:, 1:-1], 
+             jnp.zeros((num_vars, 1))))
+    
+    crank_nicolson_jac = jit(jacfwd(crank_nicolson_rhs))
+
+    """
+    Now solve for steady flamelets by combining pseudo-time stepping and
+    Newton iterations.
+    """
+    # Solver config
+    config = {}
+    config['num_iter'] = 20
+    config['crank_nicolson'] = {}
+    config['crank_nicolson']['dt'] = 1e-5
+    config['crank_nicolson']['num_steps'] = 5
+    config['crank_nicolson']['newton_it'] = 20
+    config['crank_nicolson']['newton_tol'] = 1e-6
+    config['crank_nicolson']['verbosity'] = 0
+    config['newton'] = {}
+    config['newton']['num_it'] = 5
+    config['newton']['tol'] = 1e-6
+
+    # Solve for steady flamelet
+    working_state = state
+
+    for it in range(config['num_iter']):
+        print("Chirometheus: i = %i, t = %.4e" % 
+              (it, 5.0 * it * config['crank_nicolson']['dt']))
+        # Advance first
+        working_state = crank_nicolson(crank_nicolson_rhs, crank_nicolson_jac,
+                                    num_vars, num_points, working_state,
+                                    config['crank_nicolson']['dt'], 
+                                    config['crank_nicolson']['num_steps'],
+                                    config['crank_nicolson']['newton_it'],
+                                    config['crank_nicolson']['newton_tol'],
+                                    config['crank_nicolson']['verbosity'])
+        # Try Newton
+        newton_state = newton(steady_flamelet_rhs, steady_flamelet_jac, 
+                            num_vars, num_points, working_state, 
+                            num_it = config['newton']['num_it'], 
+                            tol=config['newton']['tol'])
+        if newton_state is None:
+            print("Chirometheus: Newton failed")
+        else:
+            print("Chirometheus: Newton worked: T_max = %.4f [K]" % newton_state[0].max())
+            return newton_state
+        
+    return
+
+
+if __name__ == "__main__":
+
+    steady_flamelet()
+    exit

--- a/pyrometheus/codegen/python.py
+++ b/pyrometheus/codegen/python.py
@@ -260,7 +260,11 @@ class Thermochemistry:
                 )
 
     def get_concentrations(self, rho, mass_fractions):
-        return self.iwts * rho * mass_fractions
+        return self._pyro_make_array([
+            % for i in range(sol.n_species):
+            self.iwts[${i}] * mass_fractions[${i}] * rho,
+            % endfor
+                ])
 
     def get_mass_average_property(self, mass_fractions, spec_property):
         return sum([mass_fractions[i] * spec_property[i] * self.iwts[i]

--- a/test/test_codegen.py
+++ b/test/test_codegen.py
@@ -502,8 +502,6 @@ def test_pyro_on_grids(usr_np):
     temperature = temp_ox + (temp_fu - temp_ox)*grid
     density = pyro_gas.get_density(pressure, temperature, mass_frac)
     omega = pyro_gas.get_net_production_rates(density, temperature, mass_frac)
-
-    print(omega.shape)
     
     omega_ct = usr_np.array([])
     for i in range(num_points):

--- a/test/test_codegen.py
+++ b/test/test_codegen.py
@@ -379,7 +379,8 @@ def test_autodiff_accuracy():
     def chemical_source_term(mass_fractions):
         temperature = pyro_gas.get_temperature(enthalpy, guess_temp, mass_fractions)
         density = pyro_gas.get_density(pyro_gas.one_atm, temperature, mass_fractions)
-        return pyro_gas.get_net_production_rates(density, temperature, mass_fractions)
+        return pyro_gas.get_net_production_rates(
+            density, temperature, mass_fractions)
 
     from jax import jacfwd
     chemical_jacobian = jacfwd(chemical_source_term)
@@ -482,7 +483,7 @@ def test_falloff_kinetics(mechname, fuel, stoich_ratio):
 def test_pyro_on_grids(usr_np):
     """This function tests that pyrometheus-generated code
     computes Cantera-predicted production rates on grids"""
-    sol = ct.Solution(f"mechs/sandiego.yaml", "gas")
+    sol = ct.Solution("mechs/sandiego.yaml", "gas")
     pyro_gas = pyro.codegen.python.get_thermochem_class(sol)()
 
     num_points = 101
@@ -492,17 +493,17 @@ def test_pyro_on_grids(usr_np):
     temp_ox = 1200
     temp_fu = 500
 
-    sol.TPX = temp_ox, pressure, 'O2:0.2, O:0.01, N2:0.79'
+    sol.TPX = temp_ox, pressure, "O2:0.2, O:0.01, N2:0.79"
     y_ox = sol.Y
 
-    sol.TPX = temp_fu, pressure, 'H2:0.49, H:0.01, N2:0.5'
+    sol.TPX = temp_fu, pressure, "H2:0.49, H:0.01, N2:0.5"
     y_fu = sol.Y
 
     mass_frac = (y_ox + (y_fu - y_ox)*grid[:, None]).T
     temperature = temp_ox + (temp_fu - temp_ox)*grid
     density = pyro_gas.get_density(pressure, temperature, mass_frac)
     omega = pyro_gas.get_net_production_rates(density, temperature, mass_frac)
-    
+
     omega_ct = usr_np.array([])
     for i in range(num_points):
         sol.TPY = temperature[i], ct.one_atm, mass_frac[:, i]


### PR DESCRIPTION
This PR changes the generated code inside `get_concentrations` from 
`self.iwts * density * mass_fractions` 
to 
`self._pyro_make_array([self.iwts[0] * density * mass_fractions[0], ..., self.iwts[${num_species}] * density * mass_fractions[${num_species}]])`

This enables evaluating rates on grids (meaning the inputs can be multi-dimensional arrays, not point wise quantities), so a corresponding test is added. It also enables tracing the code with Pytato, but no test was added yet. 