### PR TITLE
Fix readthedocs build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -15,5 +15,6 @@ build:
     jobs:
         pre_build:
             - |
-                python .ci/generate-example-mech.py test/mechs/sandiego.yaml pyrometheus/thermochem_example.py
-                python -m pip install --editable .
+              # Generate the thermochem example and reinstall pyrometheus as editable
+              python .ci/generate-example-mech.py test/mechs/sandiego.yaml pyrometheus/thermochem_example.py
+              python -m pip install --editable .

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,4 +14,4 @@ build:
         python: "miniconda3-4.7"
     jobs:
         pre_build:
-            - pwd && python .ci/generate-example-mech.py test/mechs/sandiego.yaml pyrometheus/thermochem_example.py && ls pyrometheus
+            - pwd && ls && python .ci/generate-example-mech.py test/mechs/sandiego.yaml pyrometheus/thermochem_example.py && ls pyrometheus

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,4 +14,4 @@ build:
         python: "miniconda3-4.7"
     jobs:
         pre_build:
-            - python .ci/generate-example-mech.py test/mechs/sandiego.yaml pyrometheus/thermochem_example.py
+            - pwd && python .ci/generate-example-mech.py test/mechs/sandiego.yaml pyrometheus/thermochem_example.py && ls pyrometheus

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -18,4 +18,4 @@ build:
   jobs:
     pre_build:
       # Generate the thermochem example and reinstall pyrometheus as editable
-      - python .ci/generate-example-mech.py test/mechs/sandiego.yaml pyrometheus/thermochem_example.py && python -m pip install --editable --no-cache-dir .
+      - python .ci/generate-example-mech.py test/mechs/sandiego.yaml pyrometheus/thermochem_example.py && python -m pip install --no-cache-dir --editable .

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -15,4 +15,4 @@ build:
   jobs:
     pre_build:
       # Generate the thermochem example and reinstall pyrometheus as editable
-      - python .ci/generate-example-mech.py test/mechs/sandiego.yaml pyrometheus/thermochem_example.py && python -m pip install --editable .
+      - which python && python .ci/generate-example-mech.py test/mechs/sandiego.yaml pyrometheus/thermochem_example.py && python -m pip install --editable --no-cache-dir .

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,4 +14,6 @@ build:
         python: "miniconda3-4.7"
     jobs:
         pre_build:
-            - which python && python --version && which pip && python .ci/generate-example-mech.py test/mechs/sandiego.yaml pyrometheus/thermochem_example.py && ls pyrometheus
+            - |
+                python .ci/generate-example-mech.py test/mechs/sandiego.yaml pyrometheus/thermochem_example.py
+                python -m pip install --editable .

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,4 +14,4 @@ build:
         python: "miniconda3-4.7"
     jobs:
         pre_build:
-            - which python && python --version && python .ci/generate-example-mech.py test/mechs/sandiego.yaml pyrometheus/thermochem_example.py && ls pyrometheus
+            - which python && python --version && which pip && python .ci/generate-example-mech.py test/mechs/sandiego.yaml pyrometheus/thermochem_example.py && ls pyrometheus

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,4 +14,4 @@ build:
         python: "miniconda3-4.7"
     jobs:
         pre_build:
-            - /home/docs/checkouts/readthedocs.org/user_builds/pyrometheus/conda/latest/bin/python .ci/generate-example-mech.py test/mechs/sandiego.yaml pyrometheus/thermochem_example.py && ls pyrometheus
+            - which python && /home/docs/checkouts/readthedocs.org/user_builds/pyrometheus/conda/latest/bin/python .ci/generate-example-mech.py test/mechs/sandiego.yaml pyrometheus/thermochem_example.py && ls pyrometheus

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -18,4 +18,4 @@ build:
   jobs:
     pre_build:
       # Generate the thermochem example and reinstall pyrometheus as editable
-      - conda activate $READTHEDOCS_VERSION && python .ci/generate-example-mech.py test/mechs/sandiego.yaml pyrometheus/thermochem_example.py && python -m pip install --editable .
+      - conda init bash && conda activate $READTHEDOCS_VERSION && python .ci/generate-example-mech.py test/mechs/sandiego.yaml pyrometheus/thermochem_example.py && python -m pip install --editable .

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -18,4 +18,4 @@ build:
   jobs:
     pre_build:
       # Generate the thermochem example and reinstall pyrometheus as editable
-      - /home/docs/checkouts/readthedocs.org/user_builds/$READTHEDOCS_PROJECT/conda/$READTHEDOCS_VERSION/bin/python .ci/generate-example-mech.py test/mechs/sandiego.yaml pyrometheus/thermochem_example.py && /home/docs/checkouts/readthedocs.org/user_builds/$READTHEDOCS_PROJECT/conda/$READTHEDOCS_VERSION/bin/python -m pip install --no-cache-dir --editable .
+      - conda activate $READTHEDOCS_VERSION && python .ci/generate-example-mech.py test/mechs/sandiego.yaml pyrometheus/thermochem_example.py && python -m pip install --editable .

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,4 +14,4 @@ build:
         python: "miniconda3-4.7"
     jobs:
         pre_build:
-            - python .ci/generate-example-mech.py test/mechs/sandiego.yaml pyrometheus/thermochem_example.py && pip install -e .
+            - /home/docs/checkouts/readthedocs.org/user_builds/pyrometheus/conda/latest/bin/python .ci/generate-example-mech.py test/mechs/sandiego.yaml pyrometheus/thermochem_example.py && ls pyrometheus

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,7 +14,5 @@ build:
     python: "miniconda3-4.7"
   jobs:
     pre_build:
-    # Generate the thermochem example and reinstall pyrometheus as editable
-      - |
-        python .ci/generate-example-mech.py test/mechs/sandiego.yaml pyrometheus/thermochem_example.py
-        python -m pip install --editable .
+      # Generate the thermochem example and reinstall pyrometheus as editable
+      - python .ci/generate-example-mech.py test/mechs/sandiego.yaml pyrometheus/thermochem_example.py && python -m pip install --editable .

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -18,4 +18,4 @@ build:
   jobs:
     pre_build:
       # Generate the thermochem example and reinstall pyrometheus as editable
-      - source /home/docs/.asdf/installs/python/miniconda3-4.7.12/bin/activate $READTHEDOCS_VERSION && python .ci/generate-example-mech.py test/mechs/sandiego.yaml pyrometheus/thermochem_example.py && python -m pip install --editable .
+      - conda init bash && conda activate $READTHEDOCS_VERSION && python .ci/generate-example-mech.py test/mechs/sandiego.yaml pyrometheus/thermochem_example.py && python -m pip install --editable .

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,4 +14,4 @@ build:
         python: "miniconda3-4.7"
     jobs:
         pre_build:
-            - which python && /home/docs/checkouts/readthedocs.org/user_builds/pyrometheus/conda/latest/bin/python .ci/generate-example-mech.py test/mechs/sandiego.yaml pyrometheus/thermochem_example.py && ls pyrometheus
+            - which python && /home/docs/checkouts/readthedocs.org/user_builds/pyrometheus-test/conda/latest/bin/python .ci/generate-example-mech.py test/mechs/sandiego.yaml pyrometheus/thermochem_example.py && ls pyrometheus

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -18,4 +18,4 @@ build:
   jobs:
     pre_build:
       # Generate the thermochem example and reinstall pyrometheus as editable
-      - /home/docs/checkouts/readthedocs.org/user_builds/pyrometheus-test/conda/$READTHEDOCS_VERSION/bin/python .ci/generate-example-mech.py test/mechs/sandiego.yaml pyrometheus/thermochem_example.py && /home/docs/checkouts/readthedocs.org/user_builds/pyrometheus-test/conda/$READTHEDOCS_VERSION/bin/python -m pip install --no-cache-dir --editable .
+      - /home/docs/checkouts/readthedocs.org/user_builds/$READTHEDOCS_PROJECT/conda/$READTHEDOCS_VERSION/bin/python .ci/generate-example-mech.py test/mechs/sandiego.yaml pyrometheus/thermochem_example.py && /home/docs/checkouts/readthedocs.org/user_builds/$READTHEDOCS_PROJECT/conda/$READTHEDOCS_VERSION/bin/python -m pip install --no-cache-dir --editable .

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -18,4 +18,4 @@ build:
   jobs:
     pre_build:
       # Generate the thermochem example and reinstall pyrometheus as editable
-      - $PYTHON .ci/generate-example-mech.py test/mechs/sandiego.yaml pyrometheus/thermochem_example.py && $PYTHON -m pip install --no-cache-dir --editable .
+      - /home/docs/checkouts/readthedocs.org/user_builds/pyrometheus-test/conda/$READTHEDOCS_VERSION/bin/python .ci/generate-example-mech.py test/mechs/sandiego.yaml pyrometheus/thermochem_example.py && /home/docs/checkouts/readthedocs.org/user_builds/pyrometheus-test/conda/$READTHEDOCS_VERSION/bin/python -m pip install --no-cache-dir --editable .

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,6 +8,9 @@ python:
     - method: pip
       path: .
 
+sphinx:
+  fail_on_warning: true
+
 build:
   os: ubuntu-22.04
   tools:
@@ -15,4 +18,4 @@ build:
   jobs:
     pre_build:
       # Generate the thermochem example and reinstall pyrometheus as editable
-      - which python && python .ci/generate-example-mech.py test/mechs/sandiego.yaml pyrometheus/thermochem_example.py && python -m pip install --editable --no-cache-dir .
+      - python .ci/generate-example-mech.py test/mechs/sandiego.yaml pyrometheus/thermochem_example.py && python -m pip install --editable --no-cache-dir .

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,12 +9,12 @@ python:
       path: .
 
 build:
-    os: ubuntu-22.04
-    tools:
-        python: "miniconda3-4.7"
-    jobs:
-        pre_build:
-            - |
-              # Generate the thermochem example and reinstall pyrometheus as editable
-              python .ci/generate-example-mech.py test/mechs/sandiego.yaml pyrometheus/thermochem_example.py
-              python -m pip install --editable .
+  os: ubuntu-22.04
+  tools:
+    python: "miniconda3-4.7"
+  jobs:
+    pre_build:
+    # Generate the thermochem example and reinstall pyrometheus as editable
+      - |
+        python .ci/generate-example-mech.py test/mechs/sandiego.yaml pyrometheus/thermochem_example.py
+        python -m pip install --editable .

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -18,4 +18,4 @@ build:
   jobs:
     pre_build:
       # Generate the thermochem example and reinstall pyrometheus as editable
-      - /home/docs/checkouts/readthedocs.org/user_builds/pyrometheus-test/conda/fix-rtd/bin/python .ci/generate-example-mech.py test/mechs/sandiego.yaml pyrometheus/thermochem_example.py && /home/docs/checkouts/readthedocs.org/user_builds/pyrometheus-test/conda/fix-rtd/bin/python -m pip install --no-cache-dir --editable .
+      - $PYTHON .ci/generate-example-mech.py test/mechs/sandiego.yaml pyrometheus/thermochem_example.py && $PYTHON -m pip install --no-cache-dir --editable .

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,4 +14,4 @@ build:
         python: "miniconda3-4.7"
     jobs:
         pre_build:
-            - pwd && ls && python .ci/generate-example-mech.py test/mechs/sandiego.yaml pyrometheus/thermochem_example.py && ls pyrometheus
+            - python .ci/generate-example-mech.py test/mechs/sandiego.yaml pyrometheus/thermochem_example.py && pip install -e .

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -18,4 +18,4 @@ build:
   jobs:
     pre_build:
       # Generate the thermochem example and reinstall pyrometheus as editable
-      - source /home/docs/.asdf/installs/python/miniconda3-4.7.12/bin/activate $READTHEDOCS_VERSION && python .ci/generate-example-mech.py test/mechs/sandiego.yaml pyrometheus/thermochem_example.py && python -m pip install --editable .
+      - . /home/docs/.asdf/installs/python/miniconda3-4.7.12/bin/activate $READTHEDOCS_VERSION && python .ci/generate-example-mech.py test/mechs/sandiego.yaml pyrometheus/thermochem_example.py && python -m pip install --editable .

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -18,4 +18,4 @@ build:
   jobs:
     pre_build:
       # Generate the thermochem example and reinstall pyrometheus as editable
-      - conda activate $READTHEDOCS_VERSION && python .ci/generate-example-mech.py test/mechs/sandiego.yaml pyrometheus/thermochem_example.py && python -m pip install --editable .
+      - /home/docs/checkouts/readthedocs.org/user_builds/$READTHEDOCS_PROJECT/conda/$READTHEDOCS_VERSION/bin/python .ci/generate-example-mech.py test/mechs/sandiego.yaml pyrometheus/thermochem_example.py && /home/docs/checkouts/readthedocs.org/user_builds/$READTHEDOCS_PROJECT/conda/$READTHEDOCS_VERSION/bin/python -m pip install --no-cache-dir --editable .

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -18,4 +18,4 @@ build:
   jobs:
     pre_build:
       # Generate the thermochem example and reinstall pyrometheus as editable
-      - python .ci/generate-example-mech.py test/mechs/sandiego.yaml pyrometheus/thermochem_example.py && python -m pip install --no-cache-dir --editable .
+      - /home/docs/checkouts/readthedocs.org/user_builds/pyrometheus-test/conda/fix-rtd/bin/python .ci/generate-example-mech.py test/mechs/sandiego.yaml pyrometheus/thermochem_example.py && /home/docs/checkouts/readthedocs.org/user_builds/pyrometheus-test/conda/fix-rtd/bin/python -m pip install --no-cache-dir --editable .

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -18,4 +18,4 @@ build:
   jobs:
     pre_build:
       # Generate the thermochem example and reinstall pyrometheus as editable
-      - conda init bash && conda activate $READTHEDOCS_VERSION && python .ci/generate-example-mech.py test/mechs/sandiego.yaml pyrometheus/thermochem_example.py && python -m pip install --editable .
+      - conda activate $READTHEDOCS_VERSION && python .ci/generate-example-mech.py test/mechs/sandiego.yaml pyrometheus/thermochem_example.py && python -m pip install --editable .

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -18,4 +18,4 @@ build:
   jobs:
     pre_build:
       # Generate the thermochem example and reinstall pyrometheus as editable
-      - conda init bash && conda activate $READTHEDOCS_VERSION && python .ci/generate-example-mech.py test/mechs/sandiego.yaml pyrometheus/thermochem_example.py && python -m pip install --editable .
+      - source /home/docs/.asdf/installs/python/miniconda3-4.7.12/bin/activate $READTHEDOCS_VERSION && python .ci/generate-example-mech.py test/mechs/sandiego.yaml pyrometheus/thermochem_example.py && python -m pip install --editable .

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,4 +14,4 @@ build:
         python: "miniconda3-4.7"
     jobs:
         pre_build:
-            - which python && /home/docs/checkouts/readthedocs.org/user_builds/pyrometheus-test/conda/latest/bin/python .ci/generate-example-mech.py test/mechs/sandiego.yaml pyrometheus/thermochem_example.py && ls pyrometheus
+            - which python && python --version && python .ci/generate-example-mech.py test/mechs/sandiego.yaml pyrometheus/thermochem_example.py && ls pyrometheus

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -18,4 +18,4 @@ build:
   jobs:
     pre_build:
       # Generate the thermochem example and reinstall pyrometheus as editable
-      - . /home/docs/.asdf/installs/python/miniconda3-4.7.12/bin/activate $READTHEDOCS_VERSION && python .ci/generate-example-mech.py test/mechs/sandiego.yaml pyrometheus/thermochem_example.py && python -m pip install --editable .
+      - source /home/docs/.asdf/installs/python/miniconda3-4.7.12/bin/activate $READTHEDOCS_VERSION && python .ci/generate-example-mech.py test/mechs/sandiego.yaml pyrometheus/thermochem_example.py && python -m pip install --editable .

--- a/.rtd-env-py3.yml
+++ b/.rtd-env-py3.yml
@@ -5,6 +5,7 @@ channels:
 dependencies:
 - python=3.8
 - cantera
+- pip
 - pip:
   - "sphinx-math-dollar"
   - "sphinx-copybutton"


### PR DESCRIPTION
Please *squash* this PR when merging.

Followup of #65. Fixes #63.

Current rtd builds still (silently) fail to include the generated file in the docs, since warnings are not errors. See e.g. the bottom of this log https://readthedocs.org/projects/pyrometheus/builds/19198872/.

This PR makes the build fail on warnings, uses the correct python version to generate the file, and reinstalls pyrometheus in editable mode to include the new file in the actual doc build.

Also fixes a warning regarding missing pip in the conda env.

A build log with these fixes is here: https://readthedocs.org/projects/pyrometheus-test/builds/19206561/.

```
# Current version:
$ python -m sphinx.ext.intersphinx https://pyrometheus.readthedocs.io/en/latest/objects.inv | grep Thermochemistry

# With this PR:
$ python -m sphinx.ext.intersphinx https://pyrometheus-test.readthedocs.io/en/fix-rtd/objects.inv | grep Thermochemistry
	pyrometheus.thermochem_example.Thermochemistry.gas_constant codegen.html#pyrometheus.thermochem_example.Thermochemistry.gas_constant
[...]
```

Thanks to @MTCam for the help!