### PR TITLE
Constant Cp Species Thermo

### DIFF
--- a/pyrometheus/chem_expr.py
+++ b/pyrometheus/chem_expr.py
@@ -157,8 +157,8 @@ def _(poly: ct.NasaPoly2, arg_name):
 def constant_cp_enthalpy_expr(sp_thermo: ct.ConstantCp,
                               arg_name) -> p.Expression:
     t = p.Variable(arg_name)
-    c = sp_thermo.coeffs
-    c[1:] /= ct.gas_constant
+c = sp_thermo.coeffs / ct.gas_constant
+return c[1] / t + c[3] * (1 - c[0]*ct.gas_constant / t)
     return c[1] / t + c[3] * (1 - c[0] / t)
 
 

--- a/pyrometheus/chem_expr.py
+++ b/pyrometheus/chem_expr.py
@@ -153,6 +153,15 @@ def _(poly: ct.NasaPoly2, arg_name):
 
     return nasa7_conditional(p.Variable(arg_name), poly, gen)
 
+
+def constant_cp_enthalpy_expr(sp_thermo: ct.ConstantCp, arg_name):
+    return sp_thermo[1] + sp_thermo[3] * (arg_name - sp_thermo[0])
+
+
+def constant_cp_entropy_expr(sp_thermo: ct.ConstantCp, arg_name):
+    log = p.Variable("log")
+    return sp_thermo[2] + sp_thermo[3] * (log(arg_name) - log(sp_thermo[0]))
+
 # }}}
 
 

--- a/pyrometheus/chem_expr.py
+++ b/pyrometheus/chem_expr.py
@@ -154,13 +154,21 @@ def _(poly: ct.NasaPoly2, arg_name):
     return nasa7_conditional(p.Variable(arg_name), poly, gen)
 
 
-def constant_cp_enthalpy_expr(sp_thermo: ct.ConstantCp, arg_name):
-    return sp_thermo[1] + sp_thermo[3] * (arg_name - sp_thermo[0])
+def constant_cp_enthalpy_expr(sp_thermo: ct.ConstantCp,
+                              arg_name) -> p.Expression:
+    t = p.Variable(arg_name)
+    c = sp_thermo.coeffs
+    c[1:] /= ct.gas_constant
+    return c[1] / t + c[3] * (1 - c[0] / t)
 
 
-def constant_cp_entropy_expr(sp_thermo: ct.ConstantCp, arg_name):
+def constant_cp_entropy_expr(sp_thermo: ct.ConstantCp,
+                             arg_name) -> p.Expression:
+    t = p.Variable(arg_name)
+    c = sp_thermo.coeffs
+    c[1:] /= ct.gas_constant
     log = p.Variable("log")
-    return sp_thermo[2] + sp_thermo[3] * (log(arg_name) - log(sp_thermo[0]))
+    return c[2] + c[3] * log(t/c[0])
 
 # }}}
 

--- a/pyrometheus/codegen/python.py
+++ b/pyrometheus/codegen/python.py
@@ -106,7 +106,6 @@ code_tpl = Template(
 .. autoclass:: Thermochemistry
 \"""
 
-
 import numpy as np
 
 
@@ -293,37 +292,39 @@ class Thermochemistry:
     def get_species_specific_heats_r(self, temperature):
         return self._pyro_make_array([
             % for sp in sol.species():
-            %if isinstance(sp.thermo, ct.ConstantCp):
-                ${sp.thermo.coeffs[3]} * self.usr_np.ones_like(temperature),
-            %elif isinstance(sp.thermo, ct.NasaPoly2):
+            % if isinstance(sp.thermo, ct.ConstantCp):
+                ${sp.thermo.coeffs[3]/ct.gas_constant}*self.usr_np.ones_like(temperature),
+            % elif isinstance(sp.thermo, ct.NasaPoly2):
                 ${cgm(ce.poly_to_expr(sp.thermo, "temperature"))},
-            %else:
+            % else:
                 self.usr_np.zeros_like(temperature),
+            % endif
             % endfor
                 ])
 
     def get_species_enthalpies_rt(self, temperature):
         return self._pyro_make_array([
             % for sp in sol.species():
-            %if isinstance(sp.thermo, ct.ConstantCp):
+            % if isinstance(sp.thermo, ct.ConstantCp):
                 ${cgm(ce.constant_cp_enthalpy_expr(sp.thermo, "temperature"))},
-            %elif isinstance(sp.thermo, ct.NasaPoly2):
+            % elif isinstance(sp.thermo, ct.NasaPoly2):
                 ${cgm(ce.poly_to_enthalpy_expr(sp.thermo, "temperature"))},
-            %else
+            % else:
                 self.usr_np.zeros_like(temperature),
-            %endif
+            % endif
             % endfor
                 ])
 
     def get_species_entropies_r(self, temperature):
         return self._pyro_make_array([
             % for sp in sol.species():
-            %if isinstance(sp.thermo, ct.ConstantCp):
+            % if isinstance(sp.thermo, ct.ConstantCp):
                 ${cgm(ce.constant_cp_entropy_expr(sp.thermo, "temperature"))},
-            %elif isinstance(sp.thermo, ct.NasaPoly2):
+            % elif isinstance(sp.thermo, ct.NasaPoly2):
                 ${cgm(ce.poly_to_entropy_expr(sp.thermo, "temperature"))},
-            %else:
+            % else:
                 self.usr_np.zeros_like(temperature),
+            % endif
             % endfor
                 ])
 
@@ -346,7 +347,7 @@ class Thermochemistry:
                     -0.17364695002734*temperature,
                 %endif
             %endfor
-                ])
+            ])
 
     def get_temperature(self, enthalpy_or_energy, t_guess, y, do_energy=False):
         if do_energy is False:

--- a/test/mechs/const-cp.yaml
+++ b/test/mechs/const-cp.yaml
@@ -1,0 +1,79 @@
+units: {length: cm, quantity: mol, activation-energy: cal/mol}
+
+phases:
+- name: gas
+  thermo: ideal-gas
+  elements: [O, H, C, N]
+  species: [C2H4, O2, CO2, CO, H2O, H2, N2]
+  kinetics: gas
+  reactions: all
+  state:
+    T: 300.0
+    P: 1.01325e+05
+
+species:
+- name: C2H4
+  composition: {C: 2, H: 4}
+  thermo:
+    model: constant-cp
+    T0: 300.0
+    h0: 175.264
+    s0: 219.587
+    cp0: 43.055
+- name: O2
+  composition: {O: 2}
+  thermo:
+    model: constant-cp
+    T0: 300.0
+    h0: 0.0
+    s0: 205.33
+    cp0: 29.143
+- name: CO2
+  composition: {C: 1, O: 2}
+  thermo:
+    model: constant-cp
+    T0: 300.0
+    h0: -1311.463
+    s0: 214.016
+    cp0: 37.218
+- name: CO
+  composition: {C: 1, O: 1}
+  thermo:
+    model: constant-cp
+    T0: 300.0
+    h0: -368.525
+    s0: 197.837
+    cp0: 29.143
+- name: H2O
+  composition: {H: 2, O: 1}
+  thermo:
+    model: constant-cp
+    T0: 300.0
+    h0: -805.875
+    s0: 189.036
+    cp0: 33.596
+- name: H2
+  composition: {H: 2}
+  thermo:
+    model: constant-cp
+    T0: 300.0
+    h0: 0.0
+    s0: 130.859
+    cp0: 29.143
+- name: N2
+  composition: {N: 2}
+  thermo:
+    model: constant-cp
+    T0: 300.0
+    h0: 0.0
+    s0: 191.692
+    cp0: 29.143
+
+reactions:
+- equation: C2H4 + O2 => 2 CO + 2 H2  # Reaction 1
+  rate-constant: {A: 1.0e+12, b: 0.0, Ea: 35500}
+  orders: {C2H4: 0.5, O2: 0.65}
+- equation: ' CO + 0.5 O2 <=> CO2'  # Reaction 2
+  rate-constant: {A: 1.03e+07, b: 0.7, Ea: 12000}
+- equation: ' H2 + 0.5 O2 <=> H2O'  # Reaction 3
+  rate-constant: {A: 2.81e+09, b: 0.0, Ea: 3.5e+04}

--- a/test/test_codegen.py
+++ b/test/test_codegen.py
@@ -176,7 +176,8 @@ def test_get_pressure(mechname, usr_np):
     assert abs(p_ct - p_pm) / p_ct < 1.0e-12
 
 
-@pytest.mark.parametrize("mechname", ["uiuc", "sandiego", "uconn32", "gri30"])
+@pytest.mark.parametrize("mechname", ["const-cp", "uiuc",
+                                      "sandiego", "uconn32", "gri30"])
 @pytest.mark.parametrize("usr_np", numpy_list)
 def test_get_thermo_properties(mechname, usr_np):
     """This function tests that pyrometheus-generated code
@@ -221,7 +222,7 @@ def test_get_thermo_properties(mechname, usr_np):
         print(f"keq_pm = {keq_pm}")
         print(f"keq_cnt = {keq_ct}")
         print(f"temperature = {t}")
-        # xclude meaningless check on equilibrium constants for irreversible reaction
+        # exclude meaningless check on equilibrium constants for irreversible reaction
         for i, reaction in enumerate(sol.reactions()):
             if reaction.reversible:
                 keq_err = np.abs((keq_pm[i] - keq_ct[i]) / keq_ct[i])


### PR DESCRIPTION
This pull request implements species thermo properties---enthalpy and entropy---with constant specific heats. Specific expressions are taken [from Cantera](https://cantera.org/science/species-thermo.html), and are [implemented with Pymbolic](https://github.com/pyrometheus/pyrometheus/blob/593c2163587327e813fc3abf4bcfd6deec8fc515/pyrometheus/chem_expr.py#L157). A yaml file for the uiuc mechanism with sensible values for the constant-cp-model parameters is provided. It is used in the verification test `test_get_thermo_properties`.  

A heads-up for CEESD users: constant-cp thermo is incompatible with mixture-averaged transport in Cantera. A solution object cannot be created, as the temperature is somehow evaluated to zero upon loading the yaml parameterization. I am still trying to figure out why this happens. 