### PR TITLE
Updates for Compatibility with the new Cantera 3.0 Release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
                 curl -L -O https://tiker.net/ci-support-v0
                 . ./ci-support-v0
 
-                git clone -b use_cantera30 "https://github.com/illinois-ceesd/$DOWNSTREAM_PROJECT.git"
+                git clone -b "https://github.com/illinois-ceesd/$DOWNSTREAM_PROJECT.git"
                 cd "$DOWNSTREAM_PROJECT"
                 echo "*** $DOWNSTREAM_PROJECT version: $(git rev-parse --short HEAD)"
                 edit_requirements_txt_for_downstream_in_subdir

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
                 curl -L -O https://tiker.net/ci-support-v0
                 . ./ci-support-v0
 
-                git clone "https://github.com/illinois-ceesd/$DOWNSTREAM_PROJECT.git"
+                git clone -b use_cantera30 "https://github.com/illinois-ceesd/$DOWNSTREAM_PROJECT.git"
                 cd "$DOWNSTREAM_PROJECT"
                 echo "*** $DOWNSTREAM_PROJECT version: $(git rev-parse --short HEAD)"
                 edit_requirements_txt_for_downstream_in_subdir

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
                 # "3" is intentional: It's suppposed to be conda's default
                 # Python version number, which seems to have moved past
                 # 3.9 as of 2022-02-20.
-                python_version: ["3.9", "3"]
+                python_version: ["3.9", "3.11"]
         runs-on: ubuntu-latest
         env:
             PYTHON_VERSION: ${{ matrix.python_version }}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -73,7 +73,7 @@ intersphinx_mapping = {
         "numpy": ("https://numpy.org/doc/stable/", None),
         "mirgecom": ("https://mirgecom.readthedocs.io/en/latest/", None),
         "pymbolic": ("https://documen.tician.de/pymbolic", None),
-        "cantera": ("https://cantera.org/documentation/dev/sphinx/html", None),
+        "cantera": ("https://cantera.org/documentation/docs-3.0/sphinx/html/", None),
         }
 
 autoclass_content = "class"

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -3,8 +3,7 @@ Welcome to pyrometheus's documentation!
 
 .. When you update this description, consider also updating the one in the README.
 
-Pyrometheus is a code generator for chemical mechanisms, based on
-:ref:`cantera <cantera:sec-cython-documentation>`.
+Pyrometheus is a code generator for chemical mechanisms.
 
 Here’s an example, to give you an impression:
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -3,7 +3,7 @@ Welcome to pyrometheus's documentation!
 
 .. When you update this description, consider also updating the one in the README.
 
-Pyrometheus is a code generator for chemical mechanisms, based on :ref:`cantera <cantera:_sec-cython-documentation>`.
+Pyrometheus is a code generator for chemical mechanisms, based on :ref:`cantera <cantera:sec-cython-documentation>`.
 
 Here’s an example, to give you an impression:
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -3,7 +3,7 @@ Welcome to pyrometheus's documentation!
 
 .. When you update this description, consider also updating the one in the README.
 
-Pyrometheus is a code generator for chemical mechanisms.
+Pyrometheus is a code generator for chemical mechanisms, based on :ref:`cantera <cantera:_sec-cython-documentation>`.
 
 Here’s an example, to give you an impression:
 

--- a/pyrometheus/chem_expr.py
+++ b/pyrometheus/chem_expr.py
@@ -258,7 +258,7 @@ def troe_falloff_expr(react: ct.Reaction, t):
     :returns: The Troe falloff center expression for reaction *react* in terms of the
         temperature *t* as a :class:`pymbolic.primitives.Expression`
     """
-    if hasattr("uses_legacy", react) or not react.uses_legacy:
+    if "uses_legacy" not in dir(react) or not react.uses_legacy:
         if isinstance(react.rate, ct.TroeRate):
             troe_params = react.rate.falloff_coeffs
         elif isinstance(react.rate, ct.LindemannRate):
@@ -303,7 +303,6 @@ def falloff_function_expr(react: ct.Reaction, i, t, red_pressure, falloff_center
         of the temperature *t*, reduced pressure *red_pressure*, and falloff center
         *falloff_center* as a :class:`pymbolic.primitives.Expression`
     """
-    print(react.uses_legacy)
     if "uses_legacy" not in dir(react) or not react.uses_legacy:
         # Assume Cantera 3.0
         falloff_type = react.reaction_type.split("-")[1]

--- a/pyrometheus/chem_expr.py
+++ b/pyrometheus/chem_expr.py
@@ -227,7 +227,7 @@ def third_body_efficiencies_expr(sol: ct.Solution, react: ct.Reaction, c):
         of the species concentrations *c* as a
         :class:`pymbolic.primitives.Expression`
     """
- 
+
     efficiencies = [react.third_body.efficiencies[sp]
                     for sp in react.third_body.efficiencies]
     indices_nondef = [sol.species_index(sp) for sp

--- a/pyrometheus/chem_expr.py
+++ b/pyrometheus/chem_expr.py
@@ -229,7 +229,8 @@ def third_body_efficiencies_expr(sol: ct.Solution, react: ct.Reaction, c):
         of the species concentrations *c* as a
         :class:`pymbolic.primitives.Expression`
     """
-    if isinstance(react, ct.ThreeBodyReaction):
+    if isinstance(react, ct.ThreeBodyReaction) or isinstance(react,
+                                                             ct.FalloffReaction):
         from warnings import warn
         warn("The 'Reaction.efficiencies' interface is deprecated and "
              "will be removed after Cantera 3. Access efficiencies via "
@@ -257,7 +258,7 @@ def troe_falloff_expr(react: ct.Reaction, t):
     :returns: The Troe falloff center expression for reaction *react* in terms of the
         temperature *t* as a :class:`pymbolic.primitives.Expression`
     """
-    if "uses_legacy" not in dir(react) or not react.uses_legacy:
+    if hasattr("uses_legacy", react) or not react.uses_legacy:
         if isinstance(react.rate, ct.TroeRate):
             troe_params = react.rate.falloff_coeffs
         elif isinstance(react.rate, ct.LindemannRate):
@@ -302,7 +303,9 @@ def falloff_function_expr(react: ct.Reaction, i, t, red_pressure, falloff_center
         of the temperature *t*, reduced pressure *red_pressure*, and falloff center
         *falloff_center* as a :class:`pymbolic.primitives.Expression`
     """
+    print(react.uses_legacy)
     if "uses_legacy" not in dir(react) or not react.uses_legacy:
+        # Assume Cantera 3.0
         falloff_type = react.reaction_type.split("-")[1]
     else:
         from warnings import warn

--- a/pyrometheus/chem_expr.py
+++ b/pyrometheus/chem_expr.py
@@ -240,7 +240,7 @@ def third_body_efficiencies_expr(sol: ct.Solution, react: ct.Reaction, c):
                            if i not in indices_nondef]
     else:
         efficiencies = [react.third_body.efficiencies[sp]
-                        for sp in react.third_body_efficiencies]
+                        for sp in react.third_body.efficiencies]
         indices_nondef = [sol.species_index(sp) for sp
                           in react.third_body.efficiencies]
         indices_default = [i for i in range(sol.n_species)

--- a/pyrometheus/chem_expr.py
+++ b/pyrometheus/chem_expr.py
@@ -229,9 +229,23 @@ def third_body_efficiencies_expr(sol: ct.Solution, react: ct.Reaction, c):
         of the species concentrations *c* as a
         :class:`pymbolic.primitives.Expression`
     """
-    efficiencies = [react.efficiencies[sp] for sp in react.efficiencies]
-    indices_nondef = [sol.species_index(sp) for sp in react.efficiencies]
-    indices_default = [i for i in range(sol.n_species) if i not in indices_nondef]
+    if isinstance(react, ct.ThreeBodyReaction):
+        from warnings import warn
+        warn("The 'Reaction.efficiencies' interface is deprecated and "
+             "will be removed after Cantera 3. Access efficiencies via "
+             "'react.third_body.efficiencies' instead")
+        efficiencies = [react.efficiencies[sp] for sp in react.efficiencies]
+        indices_nondef = [sol.species_index(sp) for sp in react.efficiencies]
+        indices_default = [i for i in range(sol.n_species)
+                           if i not in indices_nondef]
+    else:
+        efficiencies = [react.third_body.efficiencies[sp]
+                        for sp in react.third_body_efficiencies]
+        indices_nondef = [sol.species_index(sp) for sp
+                          in react.third_body.efficiencies]
+        indices_default = [i for i in range(sol.n_species)
+                           if i not in indices_nondef]
+
     sum_nondef = sum(eff_i * c[index_i] for eff_i, index_i
                      in zip(np.array(efficiencies), indices_nondef))
     sum_default = react.default_efficiency * sum(c[i] for i in indices_default)
@@ -243,10 +257,10 @@ def troe_falloff_expr(react: ct.Reaction, t):
     :returns: The Troe falloff center expression for reaction *react* in terms of the
         temperature *t* as a :class:`pymbolic.primitives.Expression`
     """
-    if not react.uses_legacy:
-        if react.rate.type == "Troe":
+    if 'uses_legacy' not in dir(react) or not react.uses_legacy:
+        if isinstance(react.rate, ct.TroeRate):
             troe_params = react.rate.falloff_coeffs
-        elif react.rate.type == "Lindemann":
+        elif isinstance(react.rate, ct.LindemannRate):
             return 1
         else:
             raise ValueError("Unexpected value of 'rate.type': "
@@ -288,8 +302,8 @@ def falloff_function_expr(react: ct.Reaction, i, t, red_pressure, falloff_center
         of the temperature *t*, reduced pressure *red_pressure*, and falloff center
         *falloff_center* as a :class:`pymbolic.primitives.Expression`
     """
-    if not react.uses_legacy:
-        falloff_type = react.rate.type
+    if 'uses_legacy' not in dir(react) or not react.uses_legacy:
+        falloff_type = react.reaction_type.split('-')[1]
     else:
         from warnings import warn
         warn("Legacy 'ct.Reaction.falloff' interface is deprecated "

--- a/pyrometheus/chem_expr.py
+++ b/pyrometheus/chem_expr.py
@@ -257,7 +257,7 @@ def troe_falloff_expr(react: ct.Reaction, t):
     :returns: The Troe falloff center expression for reaction *react* in terms of the
         temperature *t* as a :class:`pymbolic.primitives.Expression`
     """
-    if 'uses_legacy' not in dir(react) or not react.uses_legacy:
+    if "uses_legacy" not in dir(react) or not react.uses_legacy:
         if isinstance(react.rate, ct.TroeRate):
             troe_params = react.rate.falloff_coeffs
         elif isinstance(react.rate, ct.LindemannRate):
@@ -302,8 +302,8 @@ def falloff_function_expr(react: ct.Reaction, i, t, red_pressure, falloff_center
         of the temperature *t*, reduced pressure *red_pressure*, and falloff center
         *falloff_center* as a :class:`pymbolic.primitives.Expression`
     """
-    if 'uses_legacy' not in dir(react) or not react.uses_legacy:
-        falloff_type = react.reaction_type.split('-')[1]
+    if "uses_legacy" not in dir(react) or not react.uses_legacy:
+        falloff_type = react.reaction_type.split("-")[1]
     else:
         from warnings import warn
         warn("Legacy 'ct.Reaction.falloff' interface is deprecated "

--- a/pyrometheus/codegen/python.py
+++ b/pyrometheus/codegen/python.py
@@ -374,7 +374,7 @@ class Thermochemistry:
         ones = self._pyro_zeros_like(temperature) + 1.0
         k_high = self._pyro_make_array([
         %for _, react in falloff_reactions:
-            %if react.uses_legacy:
+            %if 'uses_legacy' in dir(react) and react.uses_legacy:
             ${cgm(ce.rate_coefficient_expr(
                 react.high_rate, Variable("temperature")))},
             %else:
@@ -386,7 +386,7 @@ class Thermochemistry:
 
         k_low = self._pyro_make_array([
         %for _, react in falloff_reactions:
-            %if react.uses_legacy:
+            %if 'uses_legacy' in dir(react) and react.uses_legacy:
             ${cgm(ce.rate_coefficient_expr(
                 react.low_rate, Variable("temperature")))},
             %else:
@@ -427,7 +427,7 @@ class Thermochemistry:
         ones = self._pyro_zeros_like(temperature) + 1.0
         k_fwd = [
         %for react in sol.reactions():
-        %if isinstance(react, ct.FalloffReaction):
+        %if react.equation in [r.equation for _, r in falloff_reactions]:
             0*temperature,
         %else:
             ${cgm(ce.rate_coefficient_expr(react.rate,
@@ -476,6 +476,24 @@ def gen_thermochem_code(sol: ct.Solution) -> str:
     adhering to the :class:`~pyrometheus.thermochem_example.Thermochemistry`
     interface.
     """
+    if not all([isinstance(r, ct.Reaction) for r in sol.reactions()]):
+        # Cantera version < 3.0
+        from warnings import warn
+        warn("Specific reaction types (e.g., ct.FalloffReaction) are "
+             "deprecated in Cantera 3, where all in a 'ct.Solution' "
+             "object are of generic 'ct.Reaction' type. "
+             "Identify reactions using 'ct.Reaction.reaction_type' insteady")
+        falloff_rxn = [(i, r) for i, r in enumerate(sol.reactions())
+                       if isinstance(r, ct.FalloffReaction)]
+        three_body_rxn = [(i, r) for i, r in enumerate(sol.reactions())
+                          if isinstance(r, ct.ThreeBodyReaction)]
+    else:
+        # Cantera version == 3.0
+        falloff_rxn = [(i, r) for i, r in enumerate(sol.reactions())
+                       if r.reaction_type.startswith('falloff')]
+        three_body_rxn = [(i, r) for i, r in enumerate(sol.reactions())
+                          if r.reaction_type == 'three-body-Arrhenius']
+
     return code_tpl.render(
         ct=ct,
         sol=sol,
@@ -486,10 +504,8 @@ def gen_thermochem_code(sol: ct.Solution) -> str:
 
         ce=pyrometheus.chem_expr,
 
-        falloff_reactions=[(i, react) for i, react in enumerate(sol.reactions())
-                           if isinstance(react, ct.FalloffReaction)],
-        three_body_reactions=[(i, react) for i, react in enumerate(sol.reactions())
-                             if isinstance(react, ct.ThreeBodyReaction)],
+        falloff_reactions=falloff_rxn,
+        three_body_reactions=three_body_rxn,
     )
 
 

--- a/pyrometheus/codegen/python.py
+++ b/pyrometheus/codegen/python.py
@@ -476,7 +476,7 @@ def gen_thermochem_code(sol: ct.Solution) -> str:
     adhering to the :class:`~pyrometheus.thermochem_example.Thermochemistry`
     interface.
     """
-    if not all([isinstance(r, ct.Reaction) for r in sol.reactions()]):
+    if not all((isinstance(r, ct.Reaction) for r in sol.reactions())):
         # Cantera version < 3.0
         from warnings import warn
         warn("Specific reaction types (e.g., ct.FalloffReaction) are "
@@ -490,9 +490,9 @@ def gen_thermochem_code(sol: ct.Solution) -> str:
     else:
         # Cantera version == 3.0
         falloff_rxn = [(i, r) for i, r in enumerate(sol.reactions())
-                       if r.reaction_type.startswith('falloff')]
+                       if r.reaction_type.startswith("falloff")]
         three_body_rxn = [(i, r) for i, r in enumerate(sol.reactions())
-                          if r.reaction_type == 'three-body-Arrhenius']
+                          if r.reaction_type == "three-body-Arrhenius"]
 
     return code_tpl.render(
         ct=ct,

--- a/pyrometheus/codegen/python.py
+++ b/pyrometheus/codegen/python.py
@@ -275,9 +275,9 @@ class Thermochemistry:
                 )
 
     def get_concentrations(self, rho, mass_fractions):
-        return self.self._pyro_make_array([
-            %for i_sp in range(sol.n_species):
-            self.inv_molecular_weights[i_sp] * rho * mass_fractions[i_sp],
+        return self._pyro_make_array([
+            %for i in range(sol.n_species):
+            self.inv_molecular_weights[${i}] * rho * mass_fractions[${i}],
             %endfor
         ])
 

--- a/pyrometheus/codegen/python.py
+++ b/pyrometheus/codegen/python.py
@@ -275,7 +275,11 @@ class Thermochemistry:
                 )
 
     def get_concentrations(self, rho, mass_fractions):
-        return self.inv_molecular_weights * rho * mass_fractions
+        return self.self._pyro_make_array([
+            %for i_sp in range(sol.n_species):
+            self.inv_molecular_weights[i_sp] * rho * mass_fractions[i_sp],
+            %endfor
+        ])
 
     def get_mass_average_property(self, mass_fractions, spec_property):
         return sum([

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(name="pyrometheus",
       python_requires="~=3.6",
 
       install_requires=[
-          "cantera>=3.0",
+          "cantera",
           "pymbolic",
           "mako",
           ],

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(name="pyrometheus",
       python_requires="~=3.6",
 
       install_requires=[
-          "cantera",
+          "cantera>=3.0",
           "pymbolic",
           "mako",
           ],

--- a/test/test_codegen.py
+++ b/test/test_codegen.py
@@ -123,8 +123,6 @@ def test_get_rate_coefficients(mechname, usr_np):
     three_body_reactions = [(i, r) for i, r in enumerate(sol.reactions())
                             if r.reaction_type == "three-body-Arrhenius"]
 
-    pyro_code = pyro.codegen.python.gen_thermochem_code(sol)
-
     # Test temperatures
     temp = np.linspace(500.0, 3000.0, 10)
     for t in temp:

--- a/test/test_codegen.py
+++ b/test/test_codegen.py
@@ -110,7 +110,8 @@ def test_generate_mechfile(lang_module, mechname):
         print(code, file=mech_file)
 
 
-@pytest.mark.parametrize("mechname", ["uiuc.yaml", "sandiego.yaml", "uiuc.cti"])
+@pytest.mark.parametrize("mechname", ["uiuc.yaml", "sandiego.yaml",
+                                      "uiuc.yaml"])
 @pytest.mark.parametrize("usr_np", numpy_list)
 def test_get_rate_coefficients(mechname, usr_np):
     """This function tests that pyrometheus-generated code
@@ -119,6 +120,9 @@ def test_get_rate_coefficients(mechname, usr_np):
     sol = ct.Solution(f"mechs/{mechname}", "gas")
     ptk_base_cls = pyro.codegen.python.get_thermochem_class(sol)
     ptk = make_jax_pyro_class(ptk_base_cls, usr_np)
+
+    three_body_reactions = [(i, r) for i, r in enumerate(sol.reactions())
+                            if r.reaction_type == 'three-body-Arrhenius']
 
     # Test temperatures
     temp = np.linspace(500.0, 3000.0, 10)
@@ -132,7 +136,22 @@ def test_get_rate_coefficients(mechname, usr_np):
         # Get rate coefficients and compare
         k_ct = sol.forward_rate_constants
         k_pm = ptk.get_fwd_rate_coefficients(t, c)
+
+        # It seems like Cantera 3.0 has bumped the third-body efficiency
+        # factor from the rate coefficient to the rate of progress
+        for i, r in three_body_reactions:
+            eff = np.sum([c[sol.species_index(sp)]
+                          * r.third_body.efficiencies[sp]
+                          for sp in r.third_body.efficiencies])
+            eff += np.sum([c[sp] for sp in range(sol.n_species)
+                           if sol.species_name(sp) not in
+                           r.third_body.efficiencies])
+            k_ct[i] *= eff
+
         print(k_ct)
+        print()
+        print(k_pm)
+        print()
         print(np.abs((k_ct-k_pm)/k_ct))
         assert np.linalg.norm((k_ct-k_pm)/k_ct, np.inf) < 1e-14
     return
@@ -444,8 +463,12 @@ def test_falloff_kinetics(mechname, fuel, stoich_ratio):
     sim = ct.ReactorNet([reactor])
 
     # Falloff reactions
-    i_falloff = [i for i, r in enumerate(sol.reactions())
-            if isinstance(r, ct.FalloffReaction)]
+    if not all([isinstance(r, ct.Reaction) for r in sol.reactions()]):
+        i_falloff = [i for i, r in enumerate(sol.reactions())
+                     if isinstance(r, ct.FalloffReaction)]
+    else:
+        i_falloff = [i for i, r in enumerate(sol.reactions())
+                     if r.reaction_type.startswith("falloff")]
 
     dt = 1e-6
     time = 0

--- a/test/test_codegen.py
+++ b/test/test_codegen.py
@@ -463,7 +463,7 @@ def test_falloff_kinetics(mechname, fuel, stoich_ratio):
     sim = ct.ReactorNet([reactor])
 
     # Falloff reactions
-    if not all([isinstance(r, ct.Reaction) for r in sol.reactions()]):
+    if not all((isinstance(r, ct.Reaction) for r in sol.reactions())):
         i_falloff = [i for i, r in enumerate(sol.reactions())
                      if isinstance(r, ct.FalloffReaction)]
     else:

--- a/test/test_codegen.py
+++ b/test/test_codegen.py
@@ -110,8 +110,7 @@ def test_generate_mechfile(lang_module, mechname):
         print(code, file=mech_file)
 
 
-@pytest.mark.parametrize("mechname", ["uiuc.yaml", "sandiego.yaml",
-                                      "uiuc.yaml"])
+@pytest.mark.parametrize("mechname", ["uiuc.yaml", "sandiego.yaml", "uconn32.yaml"])
 @pytest.mark.parametrize("usr_np", numpy_list)
 def test_get_rate_coefficients(mechname, usr_np):
     """This function tests that pyrometheus-generated code
@@ -124,11 +123,15 @@ def test_get_rate_coefficients(mechname, usr_np):
     three_body_reactions = [(i, r) for i, r in enumerate(sol.reactions())
                             if r.reaction_type == "three-body-Arrhenius"]
 
+    pyro_code = pyro.codegen.python.gen_thermochem_code(sol)
+
     # Test temperatures
     temp = np.linspace(500.0, 3000.0, 10)
     for t in temp:
         # Set new temperature in Cantera
-        sol.TP = t, ct.one_atm
+        sol.TPY = t, ct.one_atm, (1/sol.n_species) * np.ones(
+            (sol.n_species,)
+        )
         # Concentrations
         y = sol.Y
         rho = sol.density
@@ -143,7 +146,9 @@ def test_get_rate_coefficients(mechname, usr_np):
             eff = np.sum([c[sol.species_index(sp)]
                           * r.third_body.efficiencies[sp]
                           for sp in r.third_body.efficiencies])
-            eff += np.sum([c[sp] for sp in range(sol.n_species)
+            eff += np.sum([c[sp]
+                           * r.third_body.default_efficiency
+                           for sp in range(sol.n_species)
                            if sol.species_name(sp) not in
                            r.third_body.efficiencies])
             k_ct[i] *= eff
@@ -153,7 +158,8 @@ def test_get_rate_coefficients(mechname, usr_np):
         print(k_pm)
         print()
         print(np.abs((k_ct-k_pm)/k_ct))
-        assert np.linalg.norm((k_ct-k_pm)/k_ct, np.inf) < 1e-14
+        print(np.linalg.norm((k_ct-k_pm)/k_ct, np.inf))
+        assert np.linalg.norm((k_ct-k_pm)/k_ct, np.inf) < 1e-13
     return
 
 

--- a/test/test_codegen.py
+++ b/test/test_codegen.py
@@ -122,7 +122,7 @@ def test_get_rate_coefficients(mechname, usr_np):
     ptk = make_jax_pyro_class(ptk_base_cls, usr_np)
 
     three_body_reactions = [(i, r) for i, r in enumerate(sol.reactions())
-                            if r.reaction_type == 'three-body-Arrhenius']
+                            if r.reaction_type == "three-body-Arrhenius"]
 
     # Test temperatures
     temp = np.linspace(500.0, 3000.0, 10)


### PR DESCRIPTION
This PR updates the Pyrometheus code template and `chem_expr` module to ensure compatibility with the new Cantera release. 

The principal change in Cantera is that all reactions in a `ct.Solution` are of generic type `ct.Reaction`, no longer of any specific type (e.g., `ct.FalloffReaction`). Reaction types are now identified via the `ct.Reaction.reaction_type` interface. Pyrometheus has been updated accordingly to distinguish between elementary, falloff, and third-body reactions.  