### PR TITLE
Add pressure-dependency to entropy

### DIFF
--- a/pyrometheus/chem_expr.py
+++ b/pyrometheus/chem_expr.py
@@ -247,9 +247,9 @@ def equilibrium_constants_expr(sol: ct.Solution, reaction_index, gibbs_rt):
             for indices_prod_i, nu_prod_i in zip(indices_prod, nu_prod))
 
     # Check if reaction is termolecular
-    sum_nu_net = sum(nu_prod) - sum(nu_reac)
+    sum_nu_net = sum(nu_reac) - sum(nu_prod)
     if sum_nu_net != 0:
-        return sum_p - sum_r - sum_nu_net*p.Variable("c0")
+        return sum_p - sum_r + sum_nu_net*p.Variable("c0")
     else:
         return sum_p - sum_r
 
@@ -268,12 +268,13 @@ def rate_coefficient_expr(rate_coeff: ct.Arrhenius, t):
     a = rate_coeff.pre_exponential_factor
     b = rate_coeff.temperature_exponent
     t_a = rate_coeff.activation_energy/ct.gas_constant
-    if t_a == 0:
-        # Weakly temperature-dependent rate
-        return a * t**b
-    else:
-        # Modified Arrhenius
-        return p.Variable("exp")(np.log(a)+b*p.Variable("log")(t)-t_a/t)
+    return p.Variable("exp")(np.log(a)+b*p.Variable("log")(t)-t_a/t)
+#    if t_a == 0:
+#        # Weakly temperature-dependent rate
+#        return a * t**b
+#    else:
+#        # Modified Arrhenius
+#        return p.Variable("exp")(np.log(a)+b*p.Variable("log")(t)-t_a/t)
 
 
 def third_body_efficiencies_expr(sol: ct.Solution, react: ct.Reaction, c):
@@ -330,7 +331,7 @@ def troe_falloff_expr(react: ct.Reaction, t):
         troe_3 = p.Variable("exp")(-troe_params[3]/t)
         return p.Variable("log10")(troe_1 + troe_2 + troe_3)
     else:
-        raise ValueError("Unexpected length of 'tro_params': "
+        raise ValueError("Unexpected length of 'troe_params': "
                          f" '{len(troe_params)}'")
     return
 

--- a/pyrometheus/codegen/python.py
+++ b/pyrometheus/codegen/python.py
@@ -422,7 +422,6 @@ class Thermochemistry:
         ])
 
     def get_species_specific_heats_r(self, temperature):
-        \""" Get individual species Cp/R.\"""
         return self._pyro_make_array([
             % for sp in sol.species():
             ${cgm(ce.poly_to_expr(sp.thermo, "temperature"))},
@@ -430,7 +429,6 @@ class Thermochemistry:
                 ])
 
     def get_species_enthalpies_rt(self, temperature):
-        \""" Get individual species h/RT.\"""
         return self._pyro_make_array([
             % for sp in sol.species():
             ${cgm(ce.poly_to_enthalpy_expr(sp.thermo, "temperature"))},
@@ -438,7 +436,6 @@ class Thermochemistry:
                 ])
 
     def get_species_entropies_r(self, pressure, temperature):
-        \""" Get individual species s/R.\"""
         return self._pyro_make_array([
             % for sp in sol.species():
             ${cgm(ce.poly_to_entropy_expr(sp.thermo, "temperature"))}
@@ -447,7 +444,6 @@ class Thermochemistry:
                 ])
 
     def get_species_gibbs_rt(self, pressure, temperature):
-        \""" Get individual species G/RT.\"""
         h0_rt = self.get_species_enthalpies_rt(temperature)
         s0_r = self.get_species_entropies_r(pressure, temperature)
         return h0_rt - s0_r

--- a/pyrometheus/codegen/python.py
+++ b/pyrometheus/codegen/python.py
@@ -397,26 +397,26 @@ class Thermochemistry:
                                               mass_fractions):
         mmw = self.get_mix_molecular_weight(mass_fractions)
         mole_fracs = self.get_mole_fractions(mmw, mass_fractions)
-        bdiff_ij = self.get_species_binary_mass_diffusivities(temperature)
+        diff_ij = self.get_species_binary_mass_diffusivities(temperature)
         temp_pres = temperature**(3/2)/pressure
         zeros = self._pyro_zeros_like(temperature)
 
         x_sum = self._pyro_make_array([
             %for sp in range(sol.n_species):
             ${cgm(ce.diffusivity_mixture_rule_denom_expr(
-                sol, sp, Variable("mole_fracs"), Variable("bdiff_ij")))},
+                sol, sp, Variable("mole_fracs"), Variable("diff_ij")))},
             %endfor
             ])
         denom = self._pyro_make_array([
             %for s in range(sol.n_species):
-            x_sum[${s}] - mole_fracs[${s}]/bdiff_ij[${s}, ${s}],
+            x_sum[${s}] - mole_fracs[${s}]/diff_ij[${s}, ${s}],
             %endfor
             ])
         return self._pyro_make_array([
             % for sp in range(sol.n_species):
             temp_pres*self.usr_np.where(self.usr_np.greater(denom[${sp}], zeros),
                 (mmw - mole_fracs[${sp}] * self.wts[${sp}])/(mmw * denom[${sp}]),
-                bdiff_ij[${sp}, ${sp}]
+                diff_ij[${sp}, ${sp}]
             ),
             % endfor
         ])

--- a/pyrometheus/codegen/python.py
+++ b/pyrometheus/codegen/python.py
@@ -132,9 +132,15 @@ class Thermochemistry:
     .. automethod:: get_pressure
     .. automethod:: get_mix_molecular_weight
     .. automethod:: get_concentrations
+    .. automethod:: get_mole_fractions
+    .. automethod:: get_mass_average_property
+    .. automethod:: get_mole_average_property
     .. automethod:: get_mixture_specific_heat_cp_mass
     .. automethod:: get_mixture_specific_heat_cv_mass
     .. automethod:: get_mixture_enthalpy_mass
+    .. automethod:: get_mixture_enthalpy_mole
+    .. automethod:: get_mixture_entropy_mass
+    .. automethod:: get_mixture_entropy_mole
     .. automethod:: get_mixture_internal_energy_mass
     .. automethod:: get_species_viscosities
     .. automethod:: get_mixture_viscosity_mixavg
@@ -563,7 +569,7 @@ class Thermochemistry:
     def get_net_production_rates(self, rho, temperature, mass_fractions):
         pressure = self.get_pressure(rho, temperature, mass_fractions)
         c = self.get_concentrations(rho, mass_fractions)
-        r_net = self.get_net_rates_of_progress(pressure,temperature, c)
+        r_net = self.get_net_rates_of_progress(pressure, temperature, c)
         ones = self._pyro_zeros_like(r_net[0]) + 1.0
         return self._pyro_make_array([
         %for sp in sol.species():

--- a/pyrometheus/codegen/python.py
+++ b/pyrometheus/codegen/python.py
@@ -558,7 +558,7 @@ class Thermochemistry:
         %endif
 
         %for i, react in three_body_reactions:
-        k_fwd[${i}] *= (${cgm(ce.third_body_efficiencies_expr(
+        k_fwd[${i}] = k_fwd[${i}]*(${cgm(ce.third_body_efficiencies_expr(
             sol, react, Variable("concentrations")))})
         %endfor
         return self._pyro_make_array(k_fwd)

--- a/pyrometheus/codegen/python.py
+++ b/pyrometheus/codegen/python.py
@@ -318,8 +318,11 @@ class Thermochemistry:
         return self.inv_molecular_weights * mass_fractions * mix_mol_weight
 
     def get_mass_average_property(self, mass_fractions, spec_property):
-        return sum([mass_fractions[i] * spec_property[i] * self.iwts[i]
-                    for i in range(self.num_species)])
+        return sum([
+            mass_fractions[i]
+            * spec_property[i]
+            * self.inv_molecular_weights[i]
+            for i in range(self.num_species)])
 
     def get_mole_average_property(self, mass_fractions, spec_property):
         mmw = self.get_mix_molecular_weight(mass_fractions)

--- a/pyrometheus/codegen/python.py
+++ b/pyrometheus/codegen/python.py
@@ -464,7 +464,6 @@ class Thermochemistry:
             %endfor
                 ])
 
-
     def get_temperature(self, enthalpy_or_energy, t_guess, y, do_energy=False):
         if do_energy is False:
             pv_fun = self.get_mixture_specific_heat_cp_mass

--- a/pyrometheus/codegen/python.py
+++ b/pyrometheus/codegen/python.py
@@ -312,18 +312,10 @@ class Thermochemistry:
         )
 
     def get_concentrations(self, rho, mass_fractions):
-        return self._pyro_make_array([
-        %for i in range(sol.n_species):
-            self.inv_molecular_weights[${i}] * rho * mass_fractions[${i}],
-        %endfor
-        ])
+        return self.inv_molecular_weights * rho * mass_fractions
 
     def get_mole_fractions(self, mix_mol_weight, mass_fractions):
-        return self._pyro_make_array([
-        %for i in range(sol.n_species):
-            self.inv_molecular_weights[${i}] * mass_fractions[${i}] * mix_mol_weight,
-        %endfor
-        ])
+        return self.inv_molecular_weights * mass_fractions * mix_mol_weight
 
     def get_mass_average_property(self, mass_fractions, spec_property):
         return sum([mass_fractions[i] * spec_property[i] * self.iwts[i]

--- a/pyrometheus/codegen/python.py
+++ b/pyrometheus/codegen/python.py
@@ -489,7 +489,6 @@ class Thermochemistry:
 
     %if falloff_reactions:
     def get_falloff_rates(self, temperature, concentrations):
-        ones = self._pyro_zeros_like(temperature) + 1.0
         k_high = self._pyro_make_array([
         %for _, react in falloff_reactions:
             %if react.uses_legacy:

--- a/pyrometheus/codegen/python.py
+++ b/pyrometheus/codegen/python.py
@@ -260,6 +260,29 @@ class Thermochemistry:
         rt = self.gas_constant * temperature
         return rho * rt / mmw
 
+    def get_temperature(self, enthalpy_or_energy, t_guess, y, do_energy=False):
+        if do_energy is False:
+            pv_fun = self.get_mixture_specific_heat_cp_mass
+            he_fun = self.get_mixture_enthalpy_mass
+        else:
+            pv_fun = self.get_mixture_specific_heat_cv_mass
+            he_fun = self.get_mixture_internal_energy_mass
+
+        num_iter = 500
+        tol = 1.0e-6
+        ones = self._pyro_zeros_like(enthalpy_or_energy) + 1.0
+        t_i = t_guess * ones
+
+        for _ in range(num_iter):
+            f = enthalpy_or_energy - he_fun(t_i, y)
+            j = -pv_fun(t_i, y)
+            dt = -f / j
+            t_i += dt
+            if self._pyro_norm(dt, np.inf) < tol:
+                return t_i
+
+        raise RuntimeError("Temperature iteration failed to converge")
+
     def get_mix_molecular_weight(self, mass_fractions):
         return 1/(
         %for i in range(sol.n_species):
@@ -285,20 +308,43 @@ class Thermochemistry:
         return sum([mass_fractions[i] * spec_property[i] * self.iwts[i]
                     for i in range(self.num_species)])
 
+    def get_mole_average_property(self, mass_fractions, spec_property):
+        mmw = self.get_mix_molecular_weight(mass_fractions)
+        mole_fracs = self.get_mole_fractions(mmw, mass_fractions)
+        return sum([mole_fracs[i] * spec_property[i]
+                    for i in range(self.num_species)])
+
     def get_mixture_specific_heat_cp_mass(self, temperature, mass_fractions):
         cp0_r = self.get_species_specific_heats_r(temperature)
         cpmix = self.get_mass_average_property(mass_fractions, cp0_r)
         return self.gas_constant * cpmix
 
     def get_mixture_specific_heat_cv_mass(self, temperature, mass_fractions):
-        cp0_r = self.get_species_specific_heats_r(temperature) - 1.0
-        cpmix = self.get_mass_average_property(mass_fractions, cp0_r)
-        return self.gas_constant * cpmix
+        cv0_r = self.get_species_specific_heats_r(temperature) - 1.0
+        cvmix = self.get_mass_average_property(mass_fractions, cv0_r)
+        return self.gas_constant * cvmix
 
     def get_mixture_enthalpy_mass(self, temperature, mass_fractions):
         h0_rt = self.get_species_enthalpies_rt(temperature)
         hmix = self.get_mass_average_property(mass_fractions, h0_rt)
         return self.gas_constant * temperature * hmix
+
+    def get_mixture_enthalpy_mole(self, temperature, mass_fractions):
+        h0_rt = self.get_species_enthalpies_rt(temperature)
+        hmix = self.get_mole_average_property(mass_fractions, h0_rt)
+        return self.gas_constant * temperature * hmix
+
+    def get_mixture_entropy_mass(self, pressure, temperature, mass_fractions):
+        mmw = self.get_mix_molecular_weight(mass_fractions)
+        return self.get_mixture_entropy_mole(pressure, temperature, mass_fractions) / mmw
+
+    def get_mixture_entropy_mole(self, pressure, temperature, mass_fractions):
+        mmw = self.get_mix_molecular_weight(mass_fractions)
+        mole_fracs = self.usr_np.abs(self.get_mole_fractions(mmw, mass_fractions))
+        s0_r = self.get_species_entropies_r(pressure, temperature)
+        smix = self.get_mole_average_property(mass_fractions, s0_r)
+        xmix = self.get_mole_average_property(mass_fractions, self.usr_np.log(mole_fracs))
+        return self.gas_constant * (smix - xmix)
 
     def get_mixture_internal_energy_mass(self, temperature, mass_fractions):
         e0_rt = self.get_species_enthalpies_rt(temperature) - 1.0
@@ -307,11 +353,11 @@ class Thermochemistry:
 
     def get_species_viscosities(self, temperature):
         return self._pyro_make_array([
-                % for sp in range(sol.n_species):
-                self.usr_np.sqrt(temperature)*${cgm(ce.transport_polynomial_expr(
-                sol.get_viscosity_polynomial(sp), 2, Variable("temperature")))},
-                % endfor
-                ])
+            % for sp in range(sol.n_species):
+            self.usr_np.sqrt(temperature)*${cgm(ce.transport_polynomial_expr(
+            sol.get_viscosity_polynomial(sp), 2, Variable("temperature")))},
+            % endfor
+        ])
 
     def get_mixture_viscosity_mixavg(self, temperature, mass_fractions):
         mmw = self.get_mix_molecular_weight(mass_fractions)
@@ -322,17 +368,17 @@ class Thermochemistry:
             ${cgm(ce.viscosity_mixture_rule_wilke_expr(sol, sp,
                  Variable("mole_fracs"), Variable("viscosities")))},
             %endfor
-            ])
+        ])
         return sum(mole_fracs*viscosities/mix_rule_f)
 
     def get_species_thermal_conductivities(self, temperature):
         return self._pyro_make_array([
-                % for sp in range(sol.n_species):
-                self.usr_np.sqrt(temperature)*(${cgm(ce.transport_polynomial_expr(
-                    sol.get_thermal_conductivity_polynomial(sp), 1,
-                    Variable("temperature")))}),
-                % endfor
-                ])
+            % for sp in range(sol.n_species):
+            self.usr_np.sqrt(temperature)*(${cgm(ce.transport_polynomial_expr(
+                sol.get_thermal_conductivity_polynomial(sp), 1,
+                Variable("temperature")))}),
+            % endfor
+        ])
 
     def get_mixture_thermal_conductivity_mixavg(self, temperature, mass_fractions):
         mmw = self.get_mix_molecular_weight(mass_fractions)
@@ -343,12 +389,12 @@ class Thermochemistry:
 
     def get_species_binary_mass_diffusivities(self, temperature):
         return self._pyro_make_array([
-                % for i, j, in product(range(sol.n_species), range(sol.n_species)):
-                ${cgm(ce.transport_polynomial_expr(
-                      sol.get_binary_diff_coeffs_polynomial(i, j), 1,
-                      Variable("temperature")))},
-                % endfor
-                ]).reshape((self.num_species, self.num_species))
+            % for i, j, in product(range(sol.n_species), range(sol.n_species)):
+            ${cgm(ce.transport_polynomial_expr(
+                  sol.get_binary_diff_coeffs_polynomial(i, j), 1,
+                  Variable("temperature")))},
+            % endfor
+        ]).reshape((self.num_species, self.num_species))
 
     def get_species_mass_diffusivities_mixavg(self, pressure, temperature,
                                               mass_fractions):
@@ -370,13 +416,13 @@ class Thermochemistry:
             %endfor
             ])
         return self._pyro_make_array([
-              % for sp in range(sol.n_species):
-              temp_pres*self.usr_np.where(self.usr_np.greater(denom[${sp}], zeros),
-                  (mmw - mole_fracs[${sp}] * self.wts[${sp}])/(mmw * denom[${sp}]),
-                  bdiff_ij[${sp}, ${sp}]
-              ),
-              % endfor
-              ])
+            % for sp in range(sol.n_species):
+            temp_pres*self.usr_np.where(self.usr_np.greater(denom[${sp}], zeros),
+                (mmw - mole_fracs[${sp}] * self.wts[${sp}])/(mmw * denom[${sp}]),
+                bdiff_ij[${sp}, ${sp}]
+            ),
+            % endfor
+        ])
 
     def get_species_specific_heats_r(self, temperature):
         \""" Get individual species Cp/R.\"""
@@ -384,7 +430,7 @@ class Thermochemistry:
             % for sp in sol.species():
             ${cgm(ce.poly_to_expr(sp.thermo, "temperature"))},
             % endfor
-                ])
+        ])
 
     def get_species_enthalpies_rt(self, temperature):
         \""" Get individual species h/RT.\"""
@@ -392,60 +438,36 @@ class Thermochemistry:
             % for sp in sol.species():
             ${cgm(ce.poly_to_enthalpy_expr(sp.thermo, "temperature"))},
             % endfor
-                ])
+        ])
 
-    def get_species_entropies_r(self, temperature):
+    def get_species_entropies_r(self, pressure, temperature):
         \""" Get individual species s/R.\"""
         return self._pyro_make_array([
             % for sp in sol.species():
-                ${cgm(ce.poly_to_entropy_expr(sp.thermo, "temperature"))},
+            ${cgm(ce.poly_to_entropy_expr(sp.thermo, "temperature"))} - self.usr_np.log(pressure/101325),
             % endfor
-                ])
+        ])
 
-    def get_species_gibbs_rt(self, temperature):
+    def get_species_gibbs_rt(self, pressure, temperature):
         \""" Get individual species G/RT.\"""
         h0_rt = self.get_species_enthalpies_rt(temperature)
-        s0_r = self.get_species_entropies_r(temperature)
+        s0_r = self.get_species_entropies_r(pressure, temperature)
         return h0_rt - s0_r
 
-    def get_equilibrium_constants(self, temperature):
+    def get_equilibrium_constants(self, pressure, temperature):
         rt = self.gas_constant * temperature
-        c0 = self.usr_np.log(self.one_atm / rt)
+        c0 = self.usr_np.log(pressure / rt)
 
-        g0_rt = self.get_species_gibbs_rt(temperature)
+        g0_rt = self.get_species_gibbs_rt(pressure, temperature)
         return self._pyro_make_array([
-            %for i, react in enumerate(sol.reactions()):
-                %if react.reversible:
-                    ${cgm(ce.equilibrium_constants_expr(
-                        sol, i, Variable("g0_rt")))},
-                %else:
-                    -0.17364695002734*temperature,
-                %endif
-            %endfor
-                ])
-
-    def get_temperature(self, enthalpy_or_energy, t_guess, y, do_energy=False):
-        if do_energy is False:
-            pv_fun = self.get_mixture_specific_heat_cp_mass
-            he_fun = self.get_mixture_enthalpy_mass
-        else:
-            pv_fun = self.get_mixture_specific_heat_cv_mass
-            he_fun = self.get_mixture_internal_energy_mass
-
-        num_iter = 500
-        tol = 1.0e-6
-        ones = self._pyro_zeros_like(enthalpy_or_energy) + 1.0
-        t_i = t_guess * ones
-
-        for _ in range(num_iter):
-            f = enthalpy_or_energy - he_fun(t_i, y)
-            j = -pv_fun(t_i, y)
-            dt = -f / j
-            t_i += dt
-            if self._pyro_norm(dt, np.inf) < tol:
-                return t_i
-
-        raise RuntimeError("Temperature iteration failed to converge")
+        %for i, react in enumerate(sol.reactions()):
+            %if react.reversible:
+            ${cgm(ce.equilibrium_constants_expr(sol, i, Variable("g0_rt")))},
+            %else:
+            -0.17364695002734*temperature,
+            %endif
+        %endfor
+        ])
 
     %if falloff_reactions:
     def get_falloff_rates(self, temperature, concentrations, k_fwd):
@@ -460,7 +482,7 @@ class Thermochemistry:
                 react.rate.high_rate, Variable("temperature")))},
             %endif
         %endfor
-                ])
+        ])
 
         k_low = self._pyro_make_array([
         %for _, react in falloff_reactions:
@@ -472,20 +494,20 @@ class Thermochemistry:
                 react.rate.low_rate, Variable("temperature")))},
             %endif
         %endfor
-                ])
+        ])
 
         reduced_pressure = self._pyro_make_array([
         %for i, (_, react) in enumerate(falloff_reactions):
             (${cgm(ce.third_body_efficiencies_expr(
                 sol, react, Variable("concentrations")))})*k_low[${i}]/k_high[${i}],
         %endfor
-                            ])
+        ])
 
         falloff_center = self._pyro_make_array([
         %for _, react in falloff_reactions:
             ${cgm(ce.troe_falloff_expr(react, Variable("temperature")))},
         %endfor
-                        ])
+        ])
 
         falloff_function = self._pyro_make_array([
         %for i, (_, react) in enumerate(falloff_reactions):
@@ -512,7 +534,7 @@ class Thermochemistry:
                                         Variable("temperature")))} * ones,
         %endif
         %endfor
-                ]
+        ]
         %if falloff_reactions:
         self.get_falloff_rates(temperature, concentrations, k_fwd)
         %endif
@@ -523,27 +545,32 @@ class Thermochemistry:
         %endfor
         return self._pyro_make_array(k_fwd)
 
-    def get_net_rates_of_progress(self, temperature, concentrations):
+    def get_rev_rate_coefficients(self, pressure, temperature, concentrations):
         k_fwd = self.get_fwd_rate_coefficients(temperature, concentrations)
-        log_k_eq = self.get_equilibrium_constants(temperature)
+        log_k_eq = self.get_equilibrium_constants(pressure, temperature)
+        return self._pyro_make_array(k_fwd * self.usr_np.exp(log_k_eq))
+
+    def get_net_rates_of_progress(self, pressure, temperature, concentrations):
+        k_fwd = self.get_fwd_rate_coefficients(temperature, concentrations)
+        log_k_eq = self.get_equilibrium_constants(pressure, temperature)
         return self._pyro_make_array([
-                %for i in range(sol.n_reactions):
-                    ${cgm(ce.rate_of_progress_expr(sol, i,
-                        Variable("concentrations"),
-                        Variable("k_fwd"), Variable("log_k_eq")))},
-                %endfor
-               ])
+        %for i in range(sol.n_reactions):
+            ${cgm(ce.rate_of_progress_expr(sol, i, Variable("concentrations"),
+                Variable("k_fwd"), Variable("log_k_eq")))},
+        %endfor
+        ])
 
     def get_net_production_rates(self, rho, temperature, mass_fractions):
+        pressure = self.get_pressure(rho, temperature, mass_fractions)
         c = self.get_concentrations(rho, mass_fractions)
-        r_net = self.get_net_rates_of_progress(temperature, c)
+        r_net = self.get_net_rates_of_progress(pressure,temperature, c)
         ones = self._pyro_zeros_like(r_net[0]) + 1.0
         return self._pyro_make_array([
-            %for sp in sol.species():
-                ${cgm(ce.production_rate_expr(
-                    sol, sp.name, Variable("r_net")))} * ones,
-            %endfor
-               ])""", strict_undefined=True)
+        %for sp in sol.species():
+            ${cgm(ce.production_rate_expr(
+                sol, sp.name, Variable("r_net")))} * ones,
+        %endfor
+           ])""", strict_undefined=True)
 
 # }}}
 

--- a/test/test_codegen.py
+++ b/test/test_codegen.py
@@ -323,7 +323,7 @@ def test_kinetics(mechname, fuel, stoich_ratio, dt, tol, reactor_type, usr_np):
         return np.linalg.norm(x, np.inf)
 
     time = 0.0
-    for _ in range(500):
+    for _ in range(100):
         time += dt
         sim.advance(time)
 

--- a/test/test_codegen.py
+++ b/test/test_codegen.py
@@ -98,10 +98,9 @@ def make_jax_pyro_class(ptk_base_cls, usr_np):
 
 
 # Write out all the mechanisms for inspection
-@pytest.mark.parametrize("mechname", ["uiuc", "sandiego", "uconn32", "gri30"])
-@pytest.mark.parametrize("lang_module", [
-    pyro.codegen.python,
-    ])
+#@pytest.mark.parametrize("mechname", ["uiuc", "sandiego", "uconn32", "gri30"])
+@pytest.mark.parametrize("mechname", ["sandiego"])
+@pytest.mark.parametrize("lang_module", [pyro.codegen.python])
 def test_generate_mechfile(lang_module, mechname):
     """This "test" produces the mechanism codes."""
     sol = ct.Solution(f"mechs/{mechname}.yaml", "gas")


### PR DESCRIPTION
**Branch currently used in mirge-com. Not meant for merging.**

This commit adds missing terms to the entropy (for instance, see eq. 41 in https://www3.nd.edu/~powers/ame.60636/chemkin2000.pdf)
It can affect equilibrium constants, reverse rates and net production of species.

Verification is performed for two different types of reactors, with and without pressure variation, to check for properties at different conditions.