### PR TITLE
Correct Limit for Falloff Function

### DIFF
--- a/pyrometheus/codegen/python.py
+++ b/pyrometheus/codegen/python.py
@@ -399,14 +399,22 @@ class Thermochemistry:
 
         falloff_center = self._pyro_make_array([
         %for _, react in falloff_reactions:
-            ${cgm(ce.troe_falloff_expr(react, Variable("temperature")))},
+            ${cgm(ce.troe_falloff_center_expr(react, Variable("temperature")))},
         %endfor
                         ])
+
+        falloff_factor = self._pyro_make_array([
+        %for i, (_, react) in enumerate(falloff_reactions):
+            ${cgm(ce.troe_falloff_factor_expr(react, i,
+            Variable("reduced_pressure"), Variable("falloff_center")))},
+        %endfor
+        ])
 
         falloff_function = self._pyro_make_array([
         %for i, (_, react) in enumerate(falloff_reactions):
             ${cgm(ce.falloff_function_expr(
-                react, i, Variable("temperature"), Variable("reduced_pressure"),
+                react, i, Variable("temperature"),
+                Variable("falloff_factor"),
                 Variable("falloff_center")))},
         %endfor
                             ])*reduced_pressure/(1+reduced_pressure)

--- a/test/mechs/hong.yaml
+++ b/test/mechs/hong.yaml
@@ -1,0 +1,286 @@
+description: |-
+  ""
+
+generator: cti2yaml
+cantera-version: 2.6.0
+date: Mon, 20 Jun 2022 00:11:57 +0200
+input-files: [Hong-ct.cti]
+
+units: {length: cm, quantity: mol, activation-energy: cal/mol}
+
+phases:
+- name: gas
+  thermo: ideal-gas
+  elements: [O, H, N, Ar]
+  species: [H2, H, O, O2, OH, H2O, HO2, H2O2, N2, Ar]
+  kinetics: gas
+  reactions: all
+  transport: mixture-averaged
+  state:
+    T: 300.0
+    P: 1.01325e+05
+
+species:
+- name: H2
+  composition: {H: 2}
+  thermo:
+    model: NASA7
+    temperature-ranges: [200.0, 1000.0, 3500.0]
+    data:
+    - [2.34433112, 7.98052075e-03, -1.9478151e-05, 2.01572094e-08, -7.37611761e-12,
+      -917.935173, 0.683010238]
+    - [3.3372792, -4.94024731e-05, 4.99456778e-07, -1.79566394e-10, 2.00255376e-14,
+      -950.158922, -3.20502331]
+  transport:
+    model: gas
+    geometry: linear
+    diameter: 2.92
+    well-depth: 38.0
+    polarizability: 0.79
+    rotational-relaxation: 280.0
+  note: TPIS78
+- name: H
+  composition: {H: 1}
+  thermo:
+    model: NASA7
+    temperature-ranges: [200.0, 1000.0, 3500.0]
+    data:
+    - [2.5, 7.05332819e-13, -1.99591964e-15, 2.30081632e-18, -9.27732332e-22,
+      2.54736599e+04, -0.446682853]
+    - [2.50000001, -2.30842973e-11, 1.61561948e-14, -4.73515235e-18, 4.98197357e-22,
+      2.54736599e+04, -0.446682914]
+  transport:
+    model: gas
+    geometry: atom
+    diameter: 2.05
+    well-depth: 145.0
+  note: L7/88
+- name: O
+  composition: {O: 1}
+  thermo:
+    model: NASA7
+    temperature-ranges: [200.0, 1000.0, 3500.0]
+    data:
+    - [3.1682671, -3.27931884e-03, 6.64306396e-06, -6.12806624e-09, 2.11265971e-12,
+      2.91222592e+04, 2.05193346]
+    - [2.56942078, -8.59741137e-05, 4.19484589e-08, -1.00177799e-11, 1.22833691e-15,
+      2.92175791e+04, 4.78433864]
+  transport:
+    model: gas
+    geometry: atom
+    diameter: 2.75
+    well-depth: 80.0
+  note: L1/90
+- name: O2
+  composition: {O: 2}
+  thermo:
+    model: NASA7
+    temperature-ranges: [200.0, 1000.0, 3500.0]
+    data:
+    - [3.78245636, -2.99673416e-03, 9.84730201e-06, -9.68129509e-09, 3.24372837e-12,
+      -1063.94356, 3.65767573]
+    - [3.28253784, 1.48308754e-03, -7.57966669e-07, 2.09470555e-10, -2.16717794e-14,
+      -1088.45772, 5.45323129]
+  transport:
+    model: gas
+    geometry: linear
+    diameter: 3.458
+    well-depth: 107.4
+    polarizability: 1.6
+    rotational-relaxation: 3.8
+  note: TPIS89
+- name: OH
+  composition: {H: 1, O: 1}
+  thermo:
+    model: NASA7
+    temperature-ranges: [200.0, 1000.0, 3500.0]
+    data:
+    - [3.99201543, -2.40131752e-03, 4.61793841e-06, -3.88113333e-09, 1.3641147e-12,
+      3372.27356, -0.103925458]
+    - [3.09288767, 5.48429716e-04, 1.26505228e-07, -8.79461556e-11, 1.17412376e-14,
+      3615.85, 4.4766961]
+  transport:
+    model: gas
+    geometry: linear
+    diameter: 2.75
+    well-depth: 80.0
+  note: RUS78
+- name: H2O
+  composition: {H: 2, O: 1}
+  thermo:
+    model: NASA7
+    temperature-ranges: [200.0, 1000.0, 3500.0]
+    data:
+    - [4.19864056, -2.0364341e-03, 6.52040211e-06, -5.48797062e-09, 1.77197817e-12,
+      -3.02937267e+04, -0.849032208]
+    - [3.03399249, 2.17691804e-03, -1.64072518e-07, -9.7041987e-11, 1.68200992e-14,
+      -3.00042971e+04, 4.9667701]
+  transport:
+    model: gas
+    geometry: nonlinear
+    diameter: 2.605
+    well-depth: 572.4
+    dipole: 1.844
+    rotational-relaxation: 4.0
+  note: L8/89
+- name: HO2
+  composition: {H: 1, O: 2}
+  thermo:
+    model: NASA7
+    temperature-ranges: [200.0, 1000.0, 5000.0]
+    data:
+    - [4.30179807, -4.74912097e-03, 2.11582905e-05, -2.42763914e-08, 9.29225225e-12,
+      264.018485, 3.7166622]
+    - [4.17228741, 1.88117627e-03, -3.46277286e-07, 1.94657549e-11, 1.76256905e-16,
+      31.0206839, 2.95767672]
+  transport:
+    model: gas
+    geometry: nonlinear
+    diameter: 3.458
+    well-depth: 107.4
+    rotational-relaxation: 1.0
+  note: T1/09
+- name: H2O2
+  composition: {H: 2, O: 2}
+  thermo:
+    model: NASA7
+    temperature-ranges: [200.0, 1000.0, 3500.0]
+    data:
+    - [4.27611269, -5.42822417e-04, 1.67335701e-05, -2.15770813e-08, 8.62454363e-12,
+      -1.77025821e+04, 3.43505074]
+    - [4.16500285, 4.90831694e-03, -1.90139225e-06, 3.71185986e-10, -2.87908305e-14,
+      -1.78617877e+04, 2.91615662]
+  transport:
+    model: gas
+    geometry: nonlinear
+    diameter: 3.458
+    well-depth: 107.4
+    rotational-relaxation: 3.8
+  note: L7/88
+- name: N2
+  composition: {N: 2}
+  thermo:
+    model: NASA7
+    temperature-ranges: [300.0, 1000.0, 5000.0]
+    data:
+    - [3.298677, 1.4082404e-03, -3.963222e-06, 5.641515e-09, -2.444854e-12,
+      -1020.8999, 3.950372]
+    - [2.92664, 1.4879768e-03, -5.68476e-07, 1.0097038e-10, -6.753351e-15,
+      -922.7977, 5.980528]
+  transport:
+    model: gas
+    geometry: linear
+    diameter: 3.621
+    well-depth: 97.53
+    polarizability: 1.76
+    rotational-relaxation: 4.0
+  note: '121286'
+- name: Ar
+  composition: {Ar: 1}
+  thermo:
+    model: NASA7
+    temperature-ranges: [300.0, 1000.0, 5000.0]
+    data:
+    - [2.5, 0.0, 0.0, 0.0, 0.0, -745.375, 4.366]
+    - [2.5, 0.0, 0.0, 0.0, 0.0, -745.375, 4.366]
+  transport:
+    model: gas
+    geometry: atom
+    diameter: 3.33
+    well-depth: 136.5
+  note: '120186'
+
+reactions:
+- equation: H + O2 <=> O + OH  # Reaction 1
+  rate-constant: {A: 1.04e+14, b: 0.0, Ea: 1.5286e+04}
+- equation: H + O2 (+ M) <=> HO2 (+ M)  # Reaction 2
+  type: falloff
+  low-P-rate-constant: {A: 2.65e+19, b: -1.3, Ea: 0.0}
+  high-P-rate-constant: {A: 5.59e+13, b: 0.2, Ea: 0.0}
+  Troe: {A: 0.7, T3: 1.0e-30, T1: 1.0e+30, T2: 1.0e+30}
+  efficiencies: {H2O2: 12.0, H2: 2.5, Ar: 0.0, O2: 0.0, H2O: 0.0}
+- equation: H + O2 (+ Ar) <=> HO2 (+ Ar)  # Reaction 3
+  type: falloff
+  low-P-rate-constant: {A: 6.81e+18, b: -1.2, Ea: 0.0}
+  high-P-rate-constant: {A: 5.59e+13, b: 0.2, Ea: 0.0}
+  Troe: {A: 0.7, T3: 1.0e-30, T1: 1.0e+30, T2: 1.0e+30}
+- equation: H + O2 (+ O2) <=> HO2 (+ O2)  # Reaction 4
+  type: falloff
+  low-P-rate-constant: {A: 5.69e+18, b: -1.1, Ea: 0.0}
+  high-P-rate-constant: {A: 5.59e+13, b: 0.2, Ea: 0.0}
+  Troe: {A: 0.7, T3: 1.0e-30, T1: 1.0e+30, T2: 1.0e+30}
+- equation: H + O2 (+ H2O) <=> HO2 (+ H2O)  # Reaction 5
+  type: falloff
+  low-P-rate-constant: {A: 3.7e+19, b: -1.0, Ea: 0.0}
+  high-P-rate-constant: {A: 5.59e+13, b: 0.2, Ea: 0.0}
+  Troe: {A: 0.8, T3: 1.0e-30, T1: 1.0e+30, T2: 1.0e+30}
+- equation: H2O2 (+ M) <=> 2 OH (+ M)  # Reaction 6
+  type: falloff
+  low-P-rate-constant: {A: 9.55e+15, b: 0.0, Ea: 4.2203e+04}
+  high-P-rate-constant: {A: 8.59e+14, b: 0.0, Ea: 4.856e+04}
+  Troe: {A: 1.0, T3: 1.0e-10, T1: 1.0e+10, T2: 1.0e+10}
+  efficiencies: {H2O2: 15.0, H2: 2.5, Ar: 1.0, N2: 1.5, H2O: 15.0}
+- equation: OH + H2O2 <=> HO2 + H2O  # Reaction 7
+  rate-constant: {A: 7.586e+13, b: 0.0, Ea: 7269.0}
+  duplicate: true
+- equation: OH + H2O2 <=> HO2 + H2O  # Reaction 8
+  rate-constant: {A: 1.738e+12, b: 0.0, Ea: 318.0}
+  duplicate: true
+- equation: OH + HO2 <=> H2O + O2  # Reaction 9
+  rate-constant: {A: 2.89e+13, b: 0.0, Ea: -500.0}
+- equation: 2 HO2 <=> O2 + H2O2  # Reaction 10
+  rate-constant: {A: 1.3e+11, b: 0.0, Ea: -1603.0}
+  duplicate: true
+- equation: 2 HO2 <=> O2 + H2O2  # Reaction 11
+  rate-constant: {A: 4.2e+14, b: 0.0, Ea: 1.198e+04}
+  duplicate: true
+- equation: H2O + M <=> H + OH + M  # Reaction 12
+  type: three-body
+  rate-constant: {A: 6.06e+27, b: -3.31, Ea: 1.2077e+05}
+  efficiencies: {H2: 3.0, N2: 2.0, O2: 1.5, H2O: 0.0}
+- equation: H2O + H2O <=> OH + H + H2O  # Reaction 13
+  rate-constant: {A: 1.0e+26, b: -2.44, Ea: 1.2016e+05}
+- equation: OH + OH <=> H2O + O  # Reaction 14
+  rate-constant: {A: 3.57e+04, b: 2.4, Ea: -2111.0}
+- equation: O + H2 <=> H + OH  # Reaction 15
+  rate-constant: {A: 3.82e+12, b: 0.0, Ea: 7948.0}
+  duplicate: true
+- equation: O + H2 <=> H + OH  # Reaction 16
+  rate-constant: {A: 8.79e+14, b: 0.0, Ea: 1.917e+04}
+  duplicate: true
+- equation: OH + H2 <=> H + H2O  # Reaction 17
+  rate-constant: {A: 2.17e+08, b: 1.52, Ea: 3457.0}
+- equation: H + HO2 <=> OH + OH  # Reaction 18
+  rate-constant: {A: 7.08e+13, b: 0.0, Ea: 300.0}
+- equation: H + HO2 <=> H2O + O  # Reaction 19
+  rate-constant: {A: 1.45e+12, b: 0.0, Ea: 0.0}
+- equation: H + HO2 <=> H2 + O2  # Reaction 20
+  rate-constant: {A: 3.66e+06, b: 2.087, Ea: -1450.0}
+- equation: O + HO2 <=> OH + O2  # Reaction 21
+  rate-constant: {A: 1.63e+13, b: 0.0, Ea: -445.0}
+- equation: H2O2 + H <=> HO2 + H2  # Reaction 22
+  rate-constant: {A: 1.21e+07, b: 2.0, Ea: 5200.0}
+- equation: H2O2 + H <=> H2O + OH  # Reaction 23
+  rate-constant: {A: 1.02e+13, b: 0.0, Ea: 3577.0}
+- equation: H2O2 + O <=> OH + HO2  # Reaction 24
+  rate-constant: {A: 8.43e+11, b: 0.0, Ea: 3970.0}
+- equation: H2 + M <=> H + H + M  # Reaction 25
+  type: three-body
+  rate-constant: {A: 5.84e+18, b: -1.1, Ea: 1.0438e+05}
+  efficiencies: {H2: 0.0, Ar: 1.0, N2: 0.0, H2O2: 14.4, O2: 0.0, H2O: 14.4}
+- equation: H2 + H2 <=> H + H + H2  # Reaction 26
+  rate-constant: {A: 9.03e+14, b: 0.0, Ea: 9.607e+04}
+- equation: H2 + N2 <=> H + H + N2  # Reaction 27
+  rate-constant: {A: 4.58e+19, b: -1.4, Ea: 1.0438e+05}
+- equation: H2 + O2 <=> H + H + O2  # Reaction 28
+  rate-constant: {A: 4.58e+19, b: -1.4, Ea: 1.0438e+05}
+- equation: O + O + M <=> O2 + M  # Reaction 29
+  type: three-body
+  rate-constant: {A: 6.16e+15, b: -0.5, Ea: 0.0}
+  efficiencies: {H2O2: 12.0, H2: 2.5, Ar: 0.0, H2O: 12.0}
+- equation: O + O + Ar <=> O2 + Ar  # Reaction 30
+  rate-constant: {A: 1.89e+13, b: 0.0, Ea: -1788.0}
+- equation: O + H + M <=> OH + M  # Reaction 31
+  type: three-body
+  rate-constant: {A: 4.71e+18, b: -1.0, Ea: 0.0}
+  efficiencies: {H2O2: 12.0, H2: 2.5, Ar: 0.75, H2O: 12.0}

--- a/test/test_codegen.py
+++ b/test/test_codegen.py
@@ -110,7 +110,9 @@ def test_generate_mechfile(lang_module, mechname):
         print(code, file=mech_file)
 
 
-@pytest.mark.parametrize("mechname", ["uiuc.yaml", "sandiego.yaml", "uconn32.yaml"])
+@pytest.mark.parametrize("mechname", [
+    "uiuc.yaml", "sandiego.yaml", "uconn32.yaml", "hong.yaml"
+])
 @pytest.mark.parametrize("usr_np", numpy_list)
 def test_get_rate_coefficients(mechname, usr_np):
     """This function tests that pyrometheus-generated code
@@ -161,7 +163,9 @@ def test_get_rate_coefficients(mechname, usr_np):
     return
 
 
-@pytest.mark.parametrize("mechname", ["uiuc", "sandiego", "uconn32", "gri30"])
+@pytest.mark.parametrize("mechname", [
+    "uiuc", "sandiego", "uconn32", "gri30", "hong"
+])
 @pytest.mark.parametrize("usr_np", numpy_list)
 def test_get_pressure(mechname, usr_np):
     """This function tests that pyrometheus-generated code
@@ -199,7 +203,9 @@ def test_get_pressure(mechname, usr_np):
     assert abs(p_ct - p_pm) / p_ct < 1.0e-12
 
 
-@pytest.mark.parametrize("mechname", ["uiuc", "sandiego", "uconn32", "gri30"])
+@pytest.mark.parametrize("mechname", [
+    "uiuc", "sandiego", "uconn32", "gri30", "hong"
+])
 @pytest.mark.parametrize("usr_np", numpy_list)
 def test_get_thermo_properties(mechname, usr_np):
     """This function tests that pyrometheus-generated code
@@ -258,7 +264,9 @@ def test_get_thermo_properties(mechname, usr_np):
     return
 
 
-@pytest.mark.parametrize("mechname", ["uiuc", "sandiego", "gri30"])
+@pytest.mark.parametrize("mechname", [
+    "uiuc", "sandiego", "gri30", "hong"
+])
 @pytest.mark.parametrize("usr_np", numpy_list)
 def test_get_temperature(mechname, usr_np):
     """This function tests that pyrometheus-generated code
@@ -295,9 +303,12 @@ def test_get_temperature(mechname, usr_np):
         assert np.abs(t - t_pm) < tol
 
 
-@pytest.mark.parametrize("mechname, fuel, stoich_ratio, dt",
-                         [("uiuc", "C2H4", 3.0, 1e-7),
-                          ("sandiego", "H2", 0.5, 1e-6)])
+@pytest.mark.parametrize(
+    "mechname, fuel, stoich_ratio, dt",
+    [("uiuc", "C2H4", 3.0, 1e-7),
+     ("sandiego", "H2", 0.5, 1e-6),
+     ("hong", "H2", 0.5, 1e-6)]
+)
 @pytest.mark.parametrize("usr_np", numpy_list)
 def test_kinetics(mechname, fuel, stoich_ratio, dt, usr_np):
     """This function tests that pyrometheus-generated code
@@ -437,10 +448,13 @@ def test_autodiff_accuracy():
     assert orderest > 1.95
 
 
-@pytest.mark.parametrize("mechname, fuel, stoich_ratio",
-                         [("gri30", "CH4", 2),
-                          ("uconn32", "C2H4", 3),
-                          ("sandiego", "H2", 0.5)])
+@pytest.mark.parametrize(
+    "mechname, fuel, stoich_ratio",
+    [("gri30", "CH4", 2),
+     ("uconn32", "C2H4", 3),
+     ("sandiego", "H2", 0.5),
+     ("hong", "H2", 0.5)]
+)
 def test_falloff_kinetics(mechname, fuel, stoich_ratio):
     """This function tests that pyrometheus-generated code
     computes the Cantera-predicted falloff rate coefficients"""
@@ -490,9 +504,16 @@ def test_falloff_kinetics(mechname, fuel, stoich_ratio):
 
         # Prometheus kinetics
         concentrations = ptk.get_concentrations(density, mass_fractions)
+        print(f'c = {concentrations}')
         k_pm = ptk.get_fwd_rate_coefficients(temperature, concentrations)
-        err = np.linalg.norm((k_ct[i_falloff] - k_pm[i_falloff])/k_ct[i_falloff],
-                np.inf)
+        err = np.linalg.norm(
+            np.where(
+                k_ct[i_falloff],
+                (k_ct[i_falloff] - k_pm[i_falloff])/k_ct[i_falloff],
+                0
+            ),
+            np.inf
+        )
 
         # Print
         print("T = ", reactor.T)

--- a/test/test_codegen.py
+++ b/test/test_codegen.py
@@ -504,7 +504,6 @@ def test_falloff_kinetics(mechname, fuel, stoich_ratio):
 
         # Prometheus kinetics
         concentrations = ptk.get_concentrations(density, mass_fractions)
-        print(f'c = {concentrations}')
         k_pm = ptk.get_fwd_rate_coefficients(temperature, concentrations)
         err = np.linalg.norm(
             np.where(


### PR DESCRIPTION
This PR implements the correct behavior of falloff functions in the limiting case of zero reduced pressure. This behavior can arise for Falloff reactions with only species as a third-body partner e.g., 

`H + O2 (+ Ar) <=> HO2 (+ Ar)`,

when the third-body (Ar) concentration is zero. 

To achieve the right behavior, this PR separates the expression for the falloff factor---where the problematic `log10(reduced_pressure)` appears---from the expression for the falloff function. The code template is modified accordingly. To test the generated code, the Hong mechanism, which contains the aforementioned reaction, is added to the verification suite.