### PR TITLE
Drop mirgecom downstream CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,43 +88,4 @@ jobs:
                 python .ci/generate-example-mech.py test/mechs/sandiego.yaml pyrometheus/thermochem_example.py
                 build_docs
 
-    downstream_tests:
-        strategy:
-            matrix:
-                downstream_project: [mirgecom]
-        name: Tests for downstream project ${{ matrix.downstream_project }}
-        runs-on: ubuntu-latest
-        steps:
-        -   uses: actions/checkout@v3
-        -   name: "Main Script"
-            env:
-                DOWNSTREAM_PROJECT: ${{ matrix.downstream_project }}
-            run: |
-                set -x
-                curl -L -O https://tiker.net/ci-support-v0
-                . ./ci-support-v0
-
-                git clone -b "https://github.com/illinois-ceesd/$DOWNSTREAM_PROJECT.git"
-                cd "$DOWNSTREAM_PROJECT"
-                echo "*** $DOWNSTREAM_PROJECT version: $(git rev-parse --short HEAD)"
-                edit_requirements_txt_for_downstream_in_subdir
-                # Avoid slow or complicated tests in downstream projects
-                export PYTEST_ADDOPTS="-k 'not (slowtest or octave or mpi)'"
-                if test "$DOWNSTREAM_PROJECT" = "mirgecom"; then
-                    # can't turn off MPI in mirgecom
-                    export CONDA_ENVIRONMENT=conda-env.yml
-                    echo "- mpi4py" >> "$CONDA_ENVIRONMENT"
-
-                    # Make sure not to reinstall mpi4py
-                    sed -i "/mpi4py/ d" requirements.txt
-                else
-                    sed -i "/mpi4py/ d" requirements.txt
-                    export CONDA_ENVIRONMENT=.test-conda-env-py3.yml
-
-                fi
-                build_py_project_in_conda_env
-
-                export CISUPPORT_PARALLEL_PYTEST=no
-                test_py_project
-
 # vim: sw=4


### PR DESCRIPTION
cc @ecisneros8 @MTCam 

As far as I can see, there is no intention to keep mirgecom working with pyrometheus main. So I don't see a reason to keep this test around.