### PR TITLE
Fortran: Remove extra `log10` in `fallof_center` calculation

### DIFF
--- a/pyrometheus/codegen/fortran90.py
+++ b/pyrometheus/codegen/fortran90.py
@@ -100,7 +100,7 @@ def wrap_code(s, indent=4):
 
 
 def float_to_fortran(num):
-    result = repr(num).replace("e", "d")
+    result = f"{num}".replace("e", "d")
     if "d" not in result:
         result = result+"d0"
     if num < 0:

--- a/pyrometheus/codegen/fortran90.py
+++ b/pyrometheus/codegen/fortran90.py
@@ -547,8 +547,8 @@ contains
         %endfor
 
         %for i, (_, react) in enumerate(falloff_reactions):
-        falloff_center(${i+1}) = log10(${cgm(ce.troe_falloff_expr(
-            react, Variable("temperature")))})
+        falloff_center(${i+1}) = ${cgm(ce.troe_falloff_expr(
+            react, Variable("temperature")))}
         %endfor
 
         %for i, (_, react) in enumerate(falloff_reactions):

--- a/pyrometheus/codegen/fortran90.py
+++ b/pyrometheus/codegen/fortran90.py
@@ -203,7 +203,7 @@ module_tpl = Template("""
 module ${module_name}
 
     implicit none
-    integer, parameter :: num_elements = ${sol.n_elements}
+    integer, parameter, private :: num_elements = ${sol.n_elements}
     integer, parameter :: num_species = ${sol.n_species}
     integer, parameter :: num_reactions = ${sol.n_reactions}
     integer, parameter :: num_falloff = ${len(falloff_reactions)}


### PR DESCRIPTION
In the Python version of Pyrometheus,

https://github.com/pyrometheus/pyrometheus/blob/facbb7de69f4804ceb7e3392e803d021273a9f19/pyrometheus/codegen/python.py#L421-L424

while in the Fortran version,

https://github.com/pyrometheus/pyrometheus/blob/facbb7de69f4804ceb7e3392e803d021273a9f19/pyrometheus/codegen/fortran90.py#L549-L552

We notice the unintended addition of the `log10`. This PR removes it. I wrote a quick test to exercise this, which simply does:

```f90
    call get_density(P, T, Ys, rho)
    call get_mixture_energy_mass(T, Ys, energy)
    call get_net_production_rates(rho, T, Ys, omega)
```

for a mixture with predefined pressure, temperature, and mass fractions.

Before: Notice the presence of NaNs.
```console
$ gfortran-13 ftest.f90 m_thermochem.f90 -o ftest && ./ftest
  -1.5384749703427377E-004   1.5384752686889953E-004   8.2904270085397090E-014  -1.5384746724110012E-004                       NaN   0.0000000000000000        1.5384746719964798E-004                       NaN   0.0000000000000000        0.0000000000000000 
```

After:
```console
$ python3 ftest.py gfortran-13 ftest.f90 m_thermochem.f90 -o ftest && ./ftest
  -1.5384749703427377E-004   1.5384752686889953E-004   8.2904270085397090E-014  -1.5384746724110012E-004   0.0000000000000000        0.0000000000000000        1.5384746719964798E-004   0.0000000000000000        0.0000000000000000        0.0000000000000000 
```

We can compare this with the Python results for the same test (Pyrometheus & Cantera)
```console
$ python3 pytest.py 
Pyrometheus:
[-2.53613603e-04  2.53613689e-04  1.24805499e-13 -2.53613517e-04
  0.00000000e+00  0.00000000e+00  2.53613517e-04  0.00000000e+00
  0.00000000e+00  0.00000000e+00]
Cantera:
[-1.13969333e-04  1.13969372e-04  5.60853178e-14 -1.13969295e-04
  0.00000000e+00  0.00000000e+00  1.13969295e-04  0.00000000e+00
  0.00000000e+00  0.00000000e+00]
Error: 2.7929e-04
```

It seems to produce correct results now!