### PR TITLE
Fix 64-bit Jax logic

### DIFF
--- a/.test-conda-env-py3.yml
+++ b/.test-conda-env-py3.yml
@@ -8,3 +8,4 @@ dependencies:
 - cantera
 - pip
 - jax
+- jaxlib=0.4.31

--- a/.test-conda-env-py3.yml
+++ b/.test-conda-env-py3.yml
@@ -7,5 +7,4 @@ dependencies:
 - python=3
 - cantera
 - pip
-- jax
-- jaxlib=0.4.31
+- jax=0.4.30

--- a/.test-conda-env-py3.yml
+++ b/.test-conda-env-py3.yml
@@ -7,4 +7,4 @@ dependencies:
 - python=3
 - cantera
 - pip
-- jax=0.4.30
+- jax=0.4.28

--- a/test/test_codegen.py
+++ b/test/test_codegen.py
@@ -36,7 +36,7 @@ except ImportError:
     numpy_list = [np]
     jnp = None
 else:
-    import jax.numpy as jnp  # noqa: F401   
+    import jax.numpy as jnp  # noqa: F401
     jax.config.update("jax_enable_x64", True)
     numpy_list = [np, jnp]
 

--- a/test/test_codegen.py
+++ b/test/test_codegen.py
@@ -37,7 +37,10 @@ except ImportError:
     jnp = None
 else:
     import jax.numpy as jnp  # noqa: F401
-    jax.config.update("jax_enable_x64", True)
+    if sys.version_info.minor < 11:
+        jax.config.update("jax_enable_x64", 1)
+    else:
+        jax.config.update("jax_enable_x64", True)
     numpy_list = [np, jnp]
 
 

--- a/test/test_codegen.py
+++ b/test/test_codegen.py
@@ -37,7 +37,7 @@ except ImportError:
     jnp = None
 else:
     import jax.numpy as jnp  # noqa: F401
-    jax.config.update("jax_enable_x64", 1)
+    jax.config.update("jax_enable_x64", True)
     numpy_list = [np, jnp]
 
 

--- a/test/test_codegen.py
+++ b/test/test_codegen.py
@@ -36,7 +36,7 @@ except ImportError:
     numpy_list = [np]
     jnp = None
 else:
-    import jax.numpy as jnp  # noqa: F401    
+    import jax.numpy as jnp  # noqa: F401   
     jax.config.update("jax_enable_x64", True)
     numpy_list = [np, jnp]
 

--- a/test/test_codegen.py
+++ b/test/test_codegen.py
@@ -36,11 +36,8 @@ except ImportError:
     numpy_list = [np]
     jnp = None
 else:
-    import jax.numpy as jnp  # noqa: F401
-    if sys.version_info.minor < 11:
-        jax.config.update("jax_enable_x64", 1)
-    else:
-        jax.config.update("jax_enable_x64", True)
+    import jax.numpy as jnp  # noqa: F401    
+    jax.config.update("jax_enable_x64", True)
     numpy_list = [np, jnp]
 
 


### PR DESCRIPTION
This PR fixes a bug that arises from an update to Jax: to enable 64-bit mode, the argument must be boolean, not an integer (as we had before).