### PR TITLE
Cosmetic changes to generated code and testing framework

### DIFF
--- a/pyrometheus/codegen/python.py
+++ b/pyrometheus/codegen/python.py
@@ -109,7 +109,6 @@ code_tpl = Template(
 \"""
 
 
-from warnings import warn
 import numpy as np
 
 

--- a/pyrometheus/codegen/python.py
+++ b/pyrometheus/codegen/python.py
@@ -67,12 +67,12 @@ class CodeGenerationMapper(StringifyMapper):
             }
 
     def map_comparison(self, expr, enclosing_prec, *args, **kwargs):
-        return (f"self.usr_np.{self.OP_NAMES[expr.operator]}"
-            f"({self.rec(expr.left, PREC_NONE, *args, **kwargs)}, "
-            f"{self.rec(expr.right, PREC_NONE, *args, **kwargs)})")
+        return (f"self.pyro_np.{self.OP_NAMES[expr.operator]}"
+                f"({self.rec(expr.left, PREC_NONE, *args, **kwargs)}, "
+                f"{self.rec(expr.right, PREC_NONE, *args, **kwargs)})")
 
     def map_if(self, expr, enclosing_prec, *args, **kwargs):
-        return "self.usr_np.where(%s, %s, %s)" % (
+        return "self.pyro_np.where(%s, %s, %s)" % (
             self.rec(expr.condition, PREC_NONE, *args, **kwargs),
             self.rec(expr.then, PREC_NONE, *args, **kwargs),
             self.rec(expr.else_, PREC_NONE, *args, **kwargs),
@@ -80,7 +80,7 @@ class CodeGenerationMapper(StringifyMapper):
 
     def map_call(self, expr, enclosing_prec, *args, **kwargs):
         return self.format(
-            "self.usr_np.%s(%s)",
+            "self.pyro_np.%s(%s)",
             self.rec(expr.function, PREC_CALL, *args, **kwargs),
             self.join_rec(", ", expr.parameters, PREC_NONE, *args, **kwargs),
         )
@@ -153,31 +153,32 @@ class Thermochemistry:
     .. automethod:: __init__
     \"""
 
-    def __init__(self, usr_np=np):
+    def __init__(self, pyro_np=np):
         \"""Initialize thermochemistry object for a mechanism.
 
         Parameters
         ----------
-        usr_np
-            :mod:`numpy`-like namespace providing at least the following functions,
+        pyro_np
+            :mod:`numpy`-like namespace providing at least the following <%
+            %>functions
             for any array ``X`` of the bulk array type:
 
-            - ``usr_np.log(X)`` (like :data:`numpy.log`)
-            - ``usr_np.log10(X)`` (like :data:`numpy.log10`)
-            - ``usr_np.exp(X)`` (like :data:`numpy.exp`)
-            - ``usr_np.where(X > 0, X_yes, X_no)`` (like :func:`numpy.where`)
-            - ``usr_np.linalg.norm(X, np.inf)`` (like :func:`numpy.linalg.norm`)
+            - ``pyro_np.log(X)`` (like :data:`numpy.log`)
+            - ``pyro_np.log10(X)`` (like :data:`numpy.log10`)
+            - ``pyro_np.exp(X)`` (like :data:`numpy.exp`)
+            - ``pyro_np.where(X > 0, X_yes, X_no)`` (like :func:`numpy.where`)
+            - ``pyro_np.linalg.norm(X)`` (like :func:`numpy.linalg.norm`)
 
-            where the "bulk array type" is a type that offers arithmetic analogous
-            to :class:`numpy.ndarray` and is used to hold all types of (potentialy
-            volumetric) "bulk data", such as temperature, pressure, mass fractions,
-            etc. This parameter defaults to *actual numpy*, so it can be ignored
+            where "bulk array type" is a type that offers arithmetic analogous
+            to :class:`numpy.ndarray` and is used to hold all types of
+            "bulk data", such as temperature, and mass fractions, etc.
+            This parameter defaults to *actual numpy*, so it can be ignored
             unless it is needed by the user (e.g. for purposes of
             GPU processing or automatic differentiation).
 
         \"""
 
-        self.usr_np = usr_np
+        self.pyro_np = pyro_np
         self.model_name = ${repr(sol.source)}
         self.num_elements = ${sol.n_elements}
         self.num_species = ${sol.n_species}
@@ -197,20 +198,6 @@ class Thermochemistry:
 
         self.molecular_weights = ${str_np(sol.molecular_weights)}
         self.inv_molecular_weights = 1/self.molecular_weights
-
-    @property
-    def wts(self):
-        warn("Thermochemistry.wts is deprecated and will go away in 2024. "
-             "Use molecular_weights instead.", DeprecationWarning, stacklevel=2)
-
-        return self.molecular_weights
-
-    @property
-    def iwts(self):
-        warn("Thermochemistry.iwts is deprecated and will go away in 2024. "
-             "Use inv_molecular_weights instead.", DeprecationWarning, stacklevel=2)
-
-        return self.inv_molecular_weights
 
     def _pyro_zeros_like(self, argument):
         # FIXME: This is imperfect, as a NaN will stay a NaN.
@@ -243,7 +230,7 @@ class Thermochemistry:
         \"""This works around numpy.linalg norm not working with scalars.
 
         If the argument is a regular ole number, it uses :func:`numpy.abs`,
-        otherwise it uses ``usr_np.linalg.norm``.
+        otherwise it uses ``pyro_np.linalg.norm``.
         \"""
         # Wrap norm for scalars
 
@@ -251,7 +238,7 @@ class Thermochemistry:
 
         if isinstance(argument, Number):
             return np.abs(argument)
-        return self.usr_np.linalg.norm(argument, normord)
+        return self.pyro_np.linalg.norm(argument, normord)
 
     def get_species_name(self, species_index):
         return self.species_name[species_index]
@@ -293,13 +280,15 @@ class Thermochemistry:
     def get_mole_fractions(self, mix_mol_weight, mass_fractions):
         return self._pyro_make_array([
             %for i in range(sol.n_species):
-            self.inv_molecular_weights[${i}] * mass_fractions[${i}] * mix_mol_weight,
+            self.inv_molecular_weights[${i}] * mass_fractions[${i}] * <%
+            %>mix_mol_weight,
             %endfor
             ])
 
     def get_mass_average_property(self, mass_fractions, spec_property):
         return sum([
-            mass_fractions[i] * spec_property[i] * self.inv_molecular_weights[i]
+            mass_fractions[i] * spec_property[i] * <%
+            %>self.inv_molecular_weights[i]
             for i in range(self.num_species)])
 
     def get_mixture_specific_heat_cp_mass(self, temperature, mass_fractions):
@@ -371,7 +360,7 @@ class Thermochemistry:
 
     def get_equilibrium_constants(self, temperature):
         rt = self.gas_constant * temperature
-        c0 = self.usr_np.log(self.one_atm / rt)
+        c0 = self.pyro_np.log(self.one_atm / rt)
 
         g0_rt = self.get_species_gibbs_rt(temperature)
         return self._pyro_make_array([
@@ -427,13 +416,14 @@ class Thermochemistry:
         reduced_pressure = self._pyro_make_array([
         %for i, (_, react) in enumerate(falloff_reactions):
             (${cgm(ce.third_body_efficiencies_expr(
-                sol, react, Variable("concentrations")))})*k_low[${i}]/k_high[${i}],
+                sol, react, Variable("concentrations")))})*k_low[${i}]/<%
+                %>k_high[${i}],
         %endfor
         ])
 
         falloff_center = self._pyro_make_array([
         %for _, react in falloff_reactions:
-            ${cgm(ce.troe_falloff_center_expr(react, Variable("temperature")))},
+            ${cgm(ce.troe_falloff_center_expr(react,Variable("temperature")))},
         %endfor
         ])
 
@@ -498,7 +488,8 @@ class Thermochemistry:
         ones = self._pyro_zeros_like(r_net[0]) + 1.0
         return self._pyro_make_array([
             %for sp in sol.species():
-            ${cgm(ce.production_rate_expr(sol, sp.name, Variable("r_net")))} * ones,
+            ${cgm(ce.production_rate_expr(sol, sp.name, Variable("r_net")))} <%
+            %>* ones,
             %endfor
             ])
 
@@ -545,7 +536,8 @@ class Thermochemistry:
             ])
         return sum(mole_fractions*viscosities/mix_rule_f)
 
-    def get_mixture_thermal_conductivity_mixavg(self, temperature, mass_fractions):
+    def get_mixture_thermal_conductivity_mixavg(self, temperature,
+                                                mass_fractions):
         mmw = self.get_mixture_molecular_weight(mass_fractions)
         mole_fractions = self.get_mole_fractions(mmw, mass_fractions)
         conductivities = self.get_species_thermal_conductivities(temperature)
@@ -573,9 +565,9 @@ class Thermochemistry:
 
         return self._pyro_make_array([
             %for sp in range(sol.n_species):
-            self.usr_np.where(self.usr_np.greater(denom[${sp}], zeros), <%
-                %>(mmw - mole_fractions[${sp}] * self.molecular_weights[${sp}])/(<%
-                    %>pressure * mmw * denom[${sp}]), <%
+            self.pyro_np.where(self.pyro_np.greater(denom[${sp}], zeros), <%
+                %>(mmw - mole_fractions[${sp}]*self.molecular_weights[${sp}]<%
+                %>)/(pressure * mmw * denom[${sp}]), <%
                 %>bdiff_ij[${sp}][${sp}] / pressure),
             %endfor
             ])
@@ -600,9 +592,9 @@ class PythonCodeGenerator(CodeGenerator):
             opts = CodeGenerationOptions()
 
         falloff_rxn = [(i, r) for i, r in enumerate(sol.reactions())
-                    if r.reaction_type.startswith("falloff")]
+                       if r.reaction_type.startswith("falloff")]
         three_body_rxn = [(i, r) for i, r in enumerate(sol.reactions())
-                        if r.reaction_type == "three-body-Arrhenius"]
+                          if r.reaction_type == "three-body-Arrhenius"]
 
         return code_tpl.render(
             ct=ct,

--- a/test/backends.py
+++ b/test/backends.py
@@ -77,13 +77,15 @@ class PythonBackend(Backend, PythonCodeGenerator):
     def _gen_jax_wrapper(base_cls):
         class JaxPyroWrapper(base_cls):
             def _pyro_make_array(self, res_list):
-                """This works around (e.g.) numpy.exp not working with object
-                arrays of :mod:`numpy` scalars. It defaults to making object arrays,
-                however if an array consists of all scalars, it makes a "plain old"
-                :class:`numpy.ndarray`.
-
-                See ``this numpy bug <https://github.com/numpy/numpy/issues/18004>`__
+                """
+                This works around (e.g.) numpy.exp not working with
+                object arrays of :mod:`numpy` scalars. It defaults to
+                making object arrays, however if an array consists of
+                all scalars, it makes a "plain old"
+                :class:`numpy.ndarray`. See this
+                ``numpy bug <https://github.com/numpy/numpy/issues/18004>`__
                 for more context.
+
                 """
 
                 from numbers import Number
@@ -91,16 +93,16 @@ class PythonBackend(Backend, PythonCodeGenerator):
                 # arrays of shape () when handed numbers
                 all_numbers = all(
                     isinstance(e, Number)
-                    or (isinstance(e, self.usr_np.ndarray) and e.shape == ())
+                    or (isinstance(e, self.pyro_np.ndarray) and e.shape == ())
                     for e in res_list)
 
                 if all_numbers:
-                    return self.usr_np.array(
-                        res_list, dtype=self.usr_np.float64
+                    return self.pyro_np.array(
+                        res_list, dtype=self.pyro_np.float64
                     )
 
-                result = self.usr_np.empty_like(
-                    self.usr_np.array(res_list),
+                result = self.pyro_np.empty_like(
+                    self.pyro_np.array(res_list),
                 )
 
                 # 'result[:] = res_list' may look tempting, however:
@@ -111,21 +113,22 @@ class PythonBackend(Backend, PythonCodeGenerator):
                 return result
 
             def _pyro_norm(self, argument, normord):
-                """This works around numpy.linalg norm not working with scalars.
-
-                If the argument is a regular ole number, it uses :func:`numpy.abs`,
-                otherwise it uses ``usr_np.linalg.norm``.
+                """
+                This works around numpy.linalg norm not working
+                with scalars.  If the argument is a regular ole
+                number, it uses :func:`numpy.abs`, otherwise it uses
+                ``pyro_np.linalg.norm``.
                 """
                 # Wrap norm for scalars
                 from numbers import Number
                 if isinstance(argument, Number):
-                    return self.usr_np.abs(argument)
+                    return self.pyro_np.abs(argument)
                 # Needed to play nicely with Jax, which frequently creates
                 # arrays of shape () when handed numbers
-                if (isinstance(argument, self.usr_np.ndarray)
+                if (isinstance(argument, self.pyro_np.ndarray)
                         and argument.shape == ()):
-                    return self.usr_np.abs(argument)
-                return self.usr_np.linalg.norm(argument, normord)
+                    return self.pyro_np.abs(argument)
+                return self.pyro_np.linalg.norm(argument, normord)
 
         return JaxPyroWrapper
 
@@ -161,9 +164,9 @@ class Pyrometheus:
     can be interacted with as if it were the original Python implementation."""
 
     def __init__(self, mechname: str, backend: Backend, user_np):
-        """Initializes an instance of Pyrometheus for a given backend and mechanism,
-        loading the previously compiled generated code and extracting the interface
-        from it.
+        """Initializes an instance of Pyrometheus for a given backend
+        and mechanism, loading the previously compiled generated code
+        and extracting the interface from it.
 
         Parameters
         ----------
@@ -174,10 +177,13 @@ class Pyrometheus:
         user_np : module
             The numpy-like module to use for array operations within the
             generated code.
+
         """
         self.backend = backend
         self.pyro = self.backend.extract_interface(
-            importlib.import_module(f"libpyro_{self.backend.get_name()}_{mechname}"),
+            importlib.import_module(
+                f"libpyro_{self.backend.get_name()}_{mechname}"
+            ),
             mechname,
             user_np
         )
@@ -192,7 +198,7 @@ class Pyrometheus:
 
 
 def pyro_init(mechname: str, user_np,
-request: pytest.FixtureRequest) -> (ct.Solution, Pyrometheus):
+              request: pytest.FixtureRequest) -> (ct.Solution, Pyrometheus):
     """Initializes an instance of Pyrometheus for the given mechanism using the
     implementation of Pyrometheus specified by the backend option passed to
     pytest as a command line argument.


### PR DESCRIPTION
This PR replaces: 
- `usr_np` with `pyro_np` in the generated Python code, and 
- `ptk` with `pyro_gas` in the testing framework. 

These changes make the code consistent with the notation in the upcoming manuscript. 