### PR TITLE
Frontier Build Error

### DIFF
--- a/pyrometheus/codegen/fortran.py
+++ b/pyrometheus/codegen/fortran.py
@@ -412,7 +412,8 @@ contains
 
         mix_property =  ( &
             %for i in range(sol.n_species):
-                + inv_molecular_weights(${i+1})*mass_fractions(${i+1})*spec_property(${i+1}) &
+                + inv_molecular_weights(${i+1})*mass_fractions(${i+1}) &
+                *spec_property(${i+1}) &
             %endfor
         )
 

--- a/pyrometheus/codegen/fortran.py
+++ b/pyrometheus/codegen/fortran.py
@@ -259,10 +259,10 @@ module ${module_name}
     ${real_type}, parameter :: gas_constant = ${float_to_fortran(ct.gas_constant)}
     ${real_type}, parameter :: molecular_weights(${sol.n_species}) = &
         (/ ${str_np(sol.molecular_weights)} /)
-    ${real_type}, parameter :: inv_weights(${sol.n_species}) = &
+    ${real_type}, parameter :: inv_molecular_weights(${sol.n_species}) = &
         (/ ${str_np(1/sol.molecular_weights)} /)
 
-    !$acc declare create(molecular_weights, inv_weights)
+    !$acc declare create(molecular_weights, inv_molecular_weights)
 
     character(len=12), parameter :: species_names(${sol.n_species}) = &
         (/ ${", ".join('"'+'{0: <12}'.format(s)+'"' for s in sol.species_names)} /)
@@ -324,7 +324,7 @@ contains
 
         specific_gas_constant = gas_constant * ( &
                 %for i in range(sol.n_species):
-                    + inv_weights(${i+1})*mass_fractions(${i+1}) &
+                    + inv_molecular_weights(${i+1})*mass_fractions(${i+1}) &
                 %endfor
                 )
 
@@ -371,7 +371,7 @@ contains
 
         mix_mol_weight = 1.0d0 / ( &
                 %for i in range(sol.n_species):
-                    + inv_weights(${i+1})*mass_fractions(${i+1}) &
+                    + inv_molecular_weights(${i+1})*mass_fractions(${i+1}) &
                 %endfor
                 )
 
@@ -385,7 +385,7 @@ contains
         ${real_type}, intent(in),  dimension(${sol.n_species}) :: mass_fractions
         ${real_type}, intent(out), dimension(${sol.n_species}) :: concentrations
 
-        concentrations = density * inv_weights * mass_fractions
+        concentrations = density * inv_molecular_weights * mass_fractions
 
     end subroutine get_concentrations
 
@@ -397,7 +397,7 @@ contains
         ${real_type}, intent(in),  dimension(${sol.n_species}) :: mass_fractions
         ${real_type}, intent(out), dimension(${sol.n_species}) :: mole_fractions
 
-        mole_fractions = inv_weights * mass_fractions * mix_mol_weight
+        mole_fractions = inv_molecular_weights * mass_fractions * mix_mol_weight
 
     end subroutine get_mole_fractions
 
@@ -412,7 +412,7 @@ contains
 
         mix_property =  ( &
             %for i in range(sol.n_species):
-                + inv_weights(${i+1})*mass_fractions(${i+1})*spec_property(${i+1}) &
+                + inv_molecular_weights(${i+1})*mass_fractions(${i+1})*spec_property(${i+1}) &
             %endfor
         )
 


### PR DESCRIPTION
When I tried to compile MFC in Frontier I got this error:

"tn-7066 ftn: ERROR S_COMPUTE_PRESSURE, File = ../../../lustre/orion/cfd154/scratch/sbryngelson/runner/actions-runner/_work/MFC/MFC/src/common/m_variables_conversion.fpp, Line = 188 Unsupported accelerator code error: Global in accelerator routine without declare -- inv_molecular_weights"

I renamed the variable inv_weights and revised the implementation of the get_mass_averaged_property subroutine. After those changes, the build completed successfully and the chemistry benchmark tests passed.