### PR TITLE
Add MFC to CI

### DIFF
--- a/.github/workflows/mfc.yml
+++ b/.github/workflows/mfc.yml
@@ -1,7 +1,10 @@
-name: 'MFC Integration'
-
-on: [push, pull_request, workflow_dispatch]
-    
+name: MFC-Integration
+on:
+    push:
+    pull_request:
+    schedule:
+        - cron: '17 3 * * 0'
+ 
 jobs:
   github:
     name: Github

--- a/.github/workflows/mfc.yml
+++ b/.github/workflows/mfc.yml
@@ -24,7 +24,8 @@ jobs:
     steps:
       - name: Clone
         uses: actions/checkout@v4
-        repository: MFlowCode/MFC
+        with:
+          repository: MFlowCode/MFC
 
       - name: Setup Ubuntu
         run: |

--- a/.github/workflows/mfc.yml
+++ b/.github/workflows/mfc.yml
@@ -7,25 +7,23 @@ jobs:
     name: Github
     strategy:
       matrix:
-        os:    ['ubuntu']
         mpi:   ['mpi']
         precision: ['']
 
         include:
-          - os:    ubuntu
-            mpi:   no-mpi
+          - mpi:   no-mpi
             precision: single
 
       fail-fast: false
     continue-on-error: true
-    runs-on: ${{ matrix.os }}-latest
+    runs-on: ubuntu-latest
 
     steps:
       - name: Clone
         uses: actions/checkout@v4
+        repository: MFlowCode/MFC
 
       - name: Setup Ubuntu
-        if:   matrix.os == 'ubuntu'
         run: |
            sudo apt update -y
            sudo apt install -y cmake gcc g++ python3 python3-dev hdf5-tools \
@@ -37,6 +35,6 @@ jobs:
 
       - name: Test
         run:  |
-          /bin/bash mfc.sh test --max-attempts 3 -j $(nproc) $OPT1
+          /bin/bash mfc.sh test -o Chemistry --max-attempts 3 -j $(nproc) $OPT1
         env:
           OPT1: ${{ matrix.mpi == 'mpi' && '--test-all' || '' }}

--- a/.github/workflows/mfc.yml
+++ b/.github/workflows/mfc.yml
@@ -10,12 +10,8 @@ jobs:
     name: Github
     strategy:
       matrix:
-        mpi:   ['mpi']
-        precision: ['']
-
-        include:
-          - mpi:   no-mpi
-            precision: single
+        mpi:         ['mpi','no-mpi']
+        precision:   ['single','no-single']
 
       fail-fast: false
     continue-on-error: true
@@ -35,10 +31,8 @@ jobs:
 
       - name: Build
         run:  |
-          /bin/bash mfc.sh test --dry-run -j $(nproc) --${{ matrix.mpi }} --${{ matrix.precision }} 
+          /bin/bash mfc.sh test --dry-run -j $(nproc) --${{ matrix.mpi }}
 
       - name: Test
         run:  |
-          /bin/bash mfc.sh test -o Chemistry --max-attempts 3 -j $(nproc) $OPT1
-        env:
-          OPT1: ${{ matrix.mpi == 'mpi' && '--test-all' || '' }}
+          /bin/bash mfc.sh test -o Chemistry --max-attempts 3 -j $(nproc) --test-all --${{ matrix.mpi }} --${{ matrix.precision}}

--- a/.github/workflows/mfc.yml
+++ b/.github/workflows/mfc.yml
@@ -1,0 +1,42 @@
+name: 'MFC Integration'
+
+on: [push, pull_request, workflow_dispatch]
+    
+jobs:
+  github:
+    name: Github
+    strategy:
+      matrix:
+        os:    ['ubuntu']
+        mpi:   ['mpi']
+        precision: ['']
+
+        include:
+          - os:    ubuntu
+            mpi:   no-mpi
+            precision: single
+
+      fail-fast: false
+    continue-on-error: true
+    runs-on: ${{ matrix.os }}-latest
+
+    steps:
+      - name: Clone
+        uses: actions/checkout@v4
+
+      - name: Setup Ubuntu
+        if:   matrix.os == 'ubuntu'
+        run: |
+           sudo apt update -y
+           sudo apt install -y cmake gcc g++ python3 python3-dev hdf5-tools \
+                    libfftw3-dev libhdf5-dev openmpi-bin libopenmpi-dev
+
+      - name: Build
+        run:  |
+          /bin/bash mfc.sh test --dry-run -j $(nproc) --${{ matrix.mpi }} --${{ matrix.precision }} 
+
+      - name: Test
+        run:  |
+          /bin/bash mfc.sh test --max-attempts 3 -j $(nproc) $OPT1
+        env:
+          OPT1: ${{ matrix.mpi == 'mpi' && '--test-all' || '' }}

--- a/.github/workflows/mfc.yml
+++ b/.github/workflows/mfc.yml
@@ -11,7 +11,6 @@ jobs:
     strategy:
       matrix:
         mpi:         ['mpi','no-mpi']
-        precision:   ['single','no-single']
 
       fail-fast: false
     continue-on-error: true
@@ -35,4 +34,4 @@ jobs:
 
       - name: Test
         run:  |
-          /bin/bash mfc.sh test -o Chemistry --max-attempts 3 -j $(nproc) --test-all --${{ matrix.mpi }} --${{ matrix.precision}}
+          /bin/bash mfc.sh test -o Chemistry --max-attempts 3 -j $(nproc) --test-all --${{ matrix.mpi }}

--- a/.github/workflows/mfc.yml
+++ b/.github/workflows/mfc.yml
@@ -8,12 +8,6 @@ on:
 jobs:
   github:
     name: Github
-    strategy:
-      matrix:
-        mpi:         ['mpi','no-mpi']
-
-      fail-fast: false
-    continue-on-error: true
     runs-on: ubuntu-latest
 
     steps:
@@ -30,8 +24,8 @@ jobs:
 
       - name: Build
         run:  |
-          /bin/bash mfc.sh test --dry-run -j $(nproc) --${{ matrix.mpi }}
+          /bin/bash mfc.sh test --dry-run -j $(nproc) --mpi
 
       - name: Test
         run:  |
-          /bin/bash mfc.sh test -o Chemistry --max-attempts 3 -j $(nproc) --test-all --${{ matrix.mpi }}
+          /bin/bash mfc.sh test -o Chemistry --max-attempts 3 -j $(nproc) --test-all


### PR DESCRIPTION
Adds MFC to the Pyro. CI.

Not perfect: MFC grabs master branch Pyro., not the PR. Not sure of a clean fix for this, but t most can be one PR behind.