### PR TITLE
GPU Routine issue with conductivity

### DIFF
--- a/pyrometheus/codegen/fortran.py
+++ b/pyrometheus/codegen/fortran.py
@@ -822,7 +822,7 @@ contains
     subroutine get_mixture_thermal_conductivity_mixavg(temperature, &
         mass_fractions, mixture_thermal_conductivity_mixavg)
 
-        GPU_ROUTINE(get_mixture_viscosity_mixavg)
+        GPU_ROUTINE(get_mixture_thermal_conductivity_mixavg)
 
         ${real_type}, intent(in) :: temperature
         ${real_type}, intent(in), dimension(${sol.n_species}) :: mass_fractions


### PR DESCRIPTION
There was a mistake in the GPU Routine of get_mixture_thermal_conductivity_mixavg