### PR TITLE
Hardcode constants in viscosity mixture rule

### DIFF
--- a/pyrometheus/chem_expr.py
+++ b/pyrometheus/chem_expr.py
@@ -251,8 +251,8 @@ def viscosity_mixture_rule_wilke_expr(sol: ct.Solution, sp, x, mu):
     w = sol.molecular_weights
     sqrt = p.Variable("sqrt")
     return sum([x[j]*(
-        1 + sqrt((mu[sp]/mu[j])*sqrt(w[j]/w[sp]))
-    )**2 / sqrt(
+        1 + sqrt((mu[sp]/mu[j])*np.sqrt(w[j]/w[sp]))
+    )**2 / np.sqrt(
         8*(1 + (w[sp]/w[j]))
     ) for j in range(sol.n_species)])
 


### PR DESCRIPTION
The mixture rule to compute viscosity had some square roots of constants (represented as NumPy floats) that were being interpreted as symbolic. Picky array libraries like PyTorch do not like this: torch.sqrt can only operate on Tensors, not np.float64. 

This PR hardcodes these square roots by pre-computing them with np.sqrt and just inserting them into the generated code as constants. 