### PR TITLE
Update examples: laminar flame simulations

### DIFF
--- a/examples/characteristics.py
+++ b/examples/characteristics.py
@@ -14,7 +14,7 @@ def characteristic_decomposition(cons_vars, prim_vars,
         (pyro_gas.get_species_enthalpies_rt(temperature) - 1) *
         pyro_gas.gas_constant * temperature
     )
-    mol_weight = pyro_gas.get_mix_molecular_weight(
+    mol_weight = pyro_gas.get_mixture_molecular_weight(
         prim_vars.mass_fractions
     )
     cp_mass = pyro_gas.get_mixture_specific_heat_cp_mass(
@@ -28,7 +28,7 @@ def characteristic_decomposition(cons_vars, prim_vars,
     )
     gamma = cp_mass / cv_mass
 
-    sound_speed = pyro_gas.usr_np.sqrt(
+    sound_speed = pyro_gas.pyro_np.sqrt(
         gamma * prim_vars.pressure / density
     )
     total_enthalpy = (
@@ -54,16 +54,16 @@ def characteristic_decomposition(cons_vars, prim_vars,
     )
 
     #
-    sign = pyro_gas.usr_np.array([-1, 1])
+    sign = pyro_gas.pyro_np.array([-1, 1])
     num_variables = pyro_gas.num_species + 2
 
-    wave_speeds = pyro_gas.usr_np.array([
+    wave_speeds = pyro_gas.pyro_np.array([
         prim_vars.velocity - sound_speed, prim_vars.velocity,
         prim_vars.velocity + sound_speed
     ])
 
     # eigenvalues: u - a, u + a
-    eigenvec_r = pyro_gas.usr_np.zeros((num_variables, num_variables))
+    eigenvec_r = pyro_gas.pyro_np.zeros((num_variables, num_variables))
     eigenvec_r[0, [0, -1]] = prim_vars.velocity + sign * sound_speed
     eigenvec_r[1, [0, -1]] = (
         total_enthalpy + sign * prim_vars.velocity * sound_speed
@@ -77,7 +77,7 @@ def characteristic_decomposition(cons_vars, prim_vars,
         (cons_vars.total_energy / density) -
         density * (dp_ddi / dp_de)
     )
-    eigenvec_r[2:, 1:-1] = pyro_gas.usr_np.eye(pyro_gas.num_species)
+    eigenvec_r[2:, 1:-1] = pyro_gas.pyro_np.eye(pyro_gas.num_species)
     return wave_speeds, eigenvec_r
 
 
@@ -87,12 +87,12 @@ def outflow_nscbc(flux_div, cons_vars, prim_vars, density, temperature,
     ws, r = characteristic_decomposition(
         cons_vars, prim_vars, density, temperature, pyro_gas,
     )
-    df_dx = pyro_gas.usr_np.hstack((
+    df_dx = pyro_gas.pyro_np.hstack((
         flux_div.momentum,
         flux_div.total_energy,
         flux_div.densities
     ))
-    l_vec = pyro_gas.usr_np.linalg.solve(r, df_dx)
+    l_vec = pyro_gas.pyro_np.linalg.solve(r, df_dx)
 
     # Subsonic outflow
     if normal == 1:

--- a/examples/domain.py
+++ b/examples/domain.py
@@ -38,12 +38,12 @@ class Mesh:
 
 class Operators:
 
-    def __init__(self, mesh: Mesh, usr_np):
+    def __init__(self, mesh: Mesh, pyro_np):
         self.mesh = mesh
-        self.usr_np = usr_np
+        self.pyro_np = pyro_np
 
     def filt(self, f):
-        return self.usr_np.concatenate((
+        return self.pyro_np.concatenate((
             # i = 0
             [
                 0.5 * (f[0] + f[1])
@@ -90,8 +90,33 @@ class Operators:
             ],
         ))
 
+    def filt_loword(self, f):
+        return self.pyro_np.concatenate((
+            # i = 0
+            [
+                0.5 * (f[0] + f[1])
+            ],
+            # i = 1
+            [
+                0.5 * f[1] + 0.25 * (f[0] + f[2])
+            ],
+            # i = 2:-2
+            (
+                (5/8) * f[2:-2] + (1/4) * (f[1:-3] + f[3:-1]) -
+                (1/16) * (f[:-4] + f[4:])
+            ),
+            # i = -2
+            [
+                0.5 * f[-2] + 0.25 * (f[-1] + f[-3])
+            ],
+            # i = -1
+            [
+                0.5 * (f[-1] + f[-2])
+            ],
+        ))
+
     def d_dx(self, f):
-        return self.usr_np.concatenate((
+        return self.pyro_np.concatenate((
             # i = 0
             [
                 -90 * f[0] + 120 * f[1] - 30 * f[2]
@@ -116,7 +141,7 @@ class Operators:
         )) / (60 * self.mesh.dx)
 
     def laplacian(self, f):
-        return self.usr_np.concatenate((
+        return self.pyro_np.concatenate((
             [2 * f[0] - 5 * f[1] + 4 * f[2] - f[3]],
             f[2:] - 2 * f[1:-1] + f[:-2],
             [-f[-4] + 4 * f[-3] - 5 * f[-2] + 2 * f[-1]]

--- a/examples/flame-pp.ipynb
+++ b/examples/flame-pp.ipynb
@@ -1,0 +1,301 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "6002f890-b642-4839-9f8b-72baa6739fc9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import h5py\n",
+    "import cantera as ct\n",
+    "import numpy as np\n",
+    "\n",
+    "from pyrometheus.codegen.python import PythonCodeGenerator as pyro\n",
+    "from matplotlib import pyplot as plt\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "plt.rcParams['text.usetex'] = True"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "dc81d1e7-ed08-425e-88a7-7f812b12628a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fuel = 'H2'\n",
+    "mech = {'H2': 'sandiego', 'C2H4': 'bfer', 'CH4': 'gri30'}\n",
+    "fuel_name = {'H2': 'hydrogen', 'C2H4': 'ethylene'}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "13546f2f-66f1-4360-8375-5edbc1adad52",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Equilibrium temperature = 2385.441\n",
+      "mixture-averaged flame speed = 2.325731 m/s\n"
+     ]
+    }
+   ],
+   "source": [
+    "equiv_ratio = 1\n",
+    "\n",
+    "sol = ct.Solution(f'../mech/{mech[fuel]}.yaml')\n",
+    "pyro_gas = pyro.get_thermochem_class(sol)(np)\n",
+    "temp_c = 300\n",
+    "sol.TP = temp_c, ct.one_atm\n",
+    "sol.set_equivalence_ratio(equiv_ratio, f'{fuel}:1', 'O2:0.21, N2:0.79')\n",
+    "rho_c = sol.density\n",
+    "yf_c = sol.Y[0]\n",
+    "\n",
+    "sol.equilibrate('HP')\n",
+    "temp_eq = sol.T\n",
+    "print(f'Equilibrium temperature = {temp_eq:.3f}')\n",
+    "\n",
+    "temp_c = 300\n",
+    "sol.TP = temp_c, ct.one_atm\n",
+    "sol.set_equivalence_ratio(equiv_ratio, f'{fuel}:1', 'O2:0.21, N2:0.79')\n",
+    "\n",
+    "ct_flame = ct.FreeFlame(sol, width=8e-2)\n",
+    "ct_flame.set_refine_criteria(ratio=3, slope=0.06, curve=0.12)\n",
+    "\n",
+    "ct_flame.transport_model = 'mixture-averaged'\n",
+    "ct_flame.solve(loglevel=0, auto=True);\n",
+    "\n",
+    "ct_flame_speed = ct_flame.velocity[0]\n",
+    "\n",
+    "print(f\"mixture-averaged flame speed = {ct_flame.velocity[0]:7f} m/s\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "685fe6e8-a0a4-4b15-8e6f-11abf86c0ff1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def load_snapshot(case_dir, snapshot_number):\n",
+    "\n",
+    "    if snapshot_number:\n",
+    "        add_zeros = 9 - len(str(snapshot_number))\n",
+    "        snap_str = add_zeros*'0' + str(snapshot_number)\n",
+    "    else:\n",
+    "        snap_str = 9*'0'\n",
+    "\n",
+    "    db = h5py.File(f'../output/{case_dir}/flame_{snap_str}.h5')\n",
+    "    t, step = db['time/time_and_step'][:]\n",
+    "    x = db['domain/mesh/x'][:]\n",
+    "\n",
+    "    density = np.sum(\n",
+    "        db['cons_vars/densities'][:, :],\n",
+    "        axis=0\n",
+    "    )\n",
+    "\n",
+    "    u = db['prim_vars/velocity'][:]\n",
+    "    temp = db['prim_vars/temperature'][:]\n",
+    "    mass_frac = db['prim_vars/mass_fractions'][:, :]\n",
+    "    return t, step, x, u, density, temp, mass_frac"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "8291d4ca-1f17-497d-8eb7-4fd8cb047440",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "er_str = f'{equiv_ratio:.1f}'.replace('.', 'd')\n",
+    "case_dir = f'flame_{fuel_name[fuel]}_er_{er_str}'\n",
+    "\n",
+    "if fuel == 'C2H4':\n",
+    "    i_start = 1001\n",
+    "    i_end = 40301\n",
+    "elif fuel == 'H2':\n",
+    "    i_start = 1000\n",
+    "    i_end = 24000 if equiv_ratio == 1.2 else 28000"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "22ef7496-6811-4d7e-93c8-a494d9f8fb8d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fresh_tol = 5\n",
+    "fresh_margin = 20\n",
+    "\n",
+    "ts = [] \n",
+    "xfront = [] \n",
+    "u_fresh = []\n",
+    "snapshots = []\n",
+    "\n",
+    "for n in range(i_start, i_end, 100):\n",
+    "    # Load simulation data\n",
+    "    t, step, x, u, rho, temp, mass_frac = load_snapshot(case_dir, n)\n",
+    "\n",
+    "    # Track progress variable front\n",
+    "    c = (temp - temp_c) / (temp_eq - temp_c)\n",
+    "    j = np.argmax(c < 0.5)\n",
+    "    x_f = x[j-1] + (0.5 - c[j-1])*(x[j]-x[j-1])/(c[j]-c[j-1])\n",
+    "    j_margin = min(fresh_margin, len(x)-j-2)\n",
+    "    mask = (np.arange(len(x)) >= j + j_margin) & (temp <= temp_c + fresh_tol)\n",
+    "\n",
+    "    # Store results\n",
+    "    ts.append(t)\n",
+    "    xfront.append(x_f)\n",
+    "    u_fresh.append(np.mean(u[mask]))\n",
+    "    snapshots.append(n)\n",
+    "\n",
+    "ts = np.asarray(ts)\n",
+    "xfront = np.asarray(xfront)\n",
+    "u_fresh = np.asarray(u_fresh)\n",
+    "\n",
+    "# Filter for smoothness\n",
+    "from scipy.signal import savgol_filter\n",
+    "xfs = savgol_filter(xfront, window_length=11, polyorder=2, mode='interp')\n",
+    "vf = np.gradient(xfs, ts)\n",
+    "sl_inst = vf - u_fresh\n",
+    "sl_mean = sl_inst[-100:].mean()\n",
+    "sl_std = sl_inst[-100:].std()\n",
+    "\n",
+    "error = np.abs(ct_flame_speed - sl_mean) / ct_flame_speed\n",
+    "\n",
+    "print(f\"pyro:: flame speed = {sl_mean:.3f} ± {sl_std:.3f} m/s\")\n",
+    "print(f'cantera:: flame speed {ct_flame_speed}')\n",
+    "print(f\"error: {100*error:.3f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "70902bcc-f4b5-4e2d-a267-6a8129e75857",
+   "metadata": {},
+   "source": [
+    "# Visualize Flame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2e46279a-ca90-49ad-b5fe-57f8a4e63c37",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "n = 20000\n",
+    "t_1, step_1, x, u_1, density_1, temp_1, mass_frac_1 = load_snapshot(case_dir, n if fuel == 'H2' else n + 1)\n",
+    "omega_1 = pyro_gas.molecular_weights[0] * pyro_gas.get_net_production_rates(\n",
+    "    density_1, temp_1, np.where(mass_frac_1 > 0, mass_frac_1, 0)\n",
+    ")[0]\n",
+    "\n",
+    "n = 22000\n",
+    "t_2, step_2, _, u_2, density_2, temp_2, mass_frac_2 = load_snapshot(case_dir, n if fuel == 'H2' else n + 1)\n",
+    "omega_2 = pyro_gas.molecular_weights[0] * pyro_gas.get_net_production_rates(\n",
+    "    density_2, temp_2, np.where(mass_frac_2 > 0, mass_frac_2, 0)\n",
+    ")[0]\n",
+    "\n",
+    "n = 23000\n",
+    "t_3, step_3, _, u_3, density_3, temp_3, mass_frac_3 = load_snapshot(case_dir, n if fuel == 'H2' else n + 1)\n",
+    "omega_3 = pyro_gas.molecular_weights[0] * pyro_gas.get_net_production_rates(\n",
+    "    density_3, temp_3, np.where(mass_frac_3 > 0, mass_frac_3, 0)\n",
+    ")[0]\n",
+    "\n",
+    "n = 24000\n",
+    "t_4, step_4, _, u_4, density_4, temp_4, mass_frac_4 = load_snapshot(case_dir, n if fuel == 'H2' else n + 1)\n",
+    "omega_4 = pyro_gas.molecular_weights[0] * pyro_gas.get_net_production_rates(\n",
+    "    density_4, temp_4, np.where(mass_frac_4 > 0, mass_frac_4, 0)\n",
+    ")[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ba561cdb-7b18-46ab-b1b4-acf1edbbba1c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots(1, 3, figsize=(12, 3))\n",
+    "ax[0].plot(x, temp_1, color='orange')\n",
+    "ax[0].plot(x, temp_2, color='red')\n",
+    "ax[0].plot(x, temp_3, color='crimson')\n",
+    "ax[0].plot(x, temp_4, color='brown')\n",
+    "ax[0].set_xlim(0.03, 0.06)\n",
+    "\n",
+    "ax[1].plot(x, mass_frac_1[1], color='orange')\n",
+    "ax[1].plot(x, mass_frac_2[1], color='red')\n",
+    "ax[1].plot(x, mass_frac_3[1], color='crimson')\n",
+    "ax[1].plot(x, mass_frac_4[1], color='brown')\n",
+    "ax[1].set_xlim(0.03, 0.06)\n",
+    "\n",
+    "ax[2].plot(x, u_1, color='orange')\n",
+    "ax[2].plot(x, u_2, color='red')\n",
+    "ax[2].plot(x, u_3, color='crimson')\n",
+    "ax[2].plot(x, u_4, color='brown')\n",
+    "ax[2].set_xlim(0.03, 0.06)\n",
+    "\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b3ad1c66-4196-4e4d-afc9-5affce101442",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c38d1dc0-7102-4e08-ab08-25b047cb17d8",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "54a39ca9-99e6-4477-a314-73d5f4c5163f",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0dd6a795-604f-43b8-b08e-ca3c395f05f1",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/input/flame_ehtylene_er_0d8.yaml
+++ b/examples/input/flame_ehtylene_er_0d8.yaml
@@ -1,0 +1,13 @@
+mech: bfer
+fuel: C2H4
+equiv_ratio: 0.8
+num_x: 4096
+x_max: 8.0e-2
+initial_time: 0
+final_time: 1.0e-2
+step_size: 1.0e-8
+num_snapshots: 100001
+write_freq: 100
+transport_model: mixavg
+output_dir: ethylene_er_0d8
+filter: True

--- a/examples/input/flame_ehtylene_er_1d0.yaml
+++ b/examples/input/flame_ehtylene_er_1d0.yaml
@@ -1,0 +1,13 @@
+mech: bfer
+fuel: C2H4
+equiv_ratio: 1.0
+num_x: 4096
+x_max: 8.0e-2
+initial_time: 0
+final_time: 1.0e-2
+step_size: 1.0e-8
+num_snapshots: 100001
+write_freq: 100
+transport_model: mixavg
+output_dir: ethylene_er_1d0
+filter: True

--- a/examples/input/flame_ehtylene_er_1d2.yaml
+++ b/examples/input/flame_ehtylene_er_1d2.yaml
@@ -1,0 +1,13 @@
+mech: bfer
+fuel: C2H4
+equiv_ratio: 1.2
+num_x: 4096
+x_max: 8.0e-2
+initial_time: 0
+final_time: 1.0e-2
+step_size: 1.0e-8
+num_snapshots: 100001
+write_freq: 100
+transport_model: mixavg
+output_dir: ethylene_er_1d2
+filter: True

--- a/examples/input/flame_hydrogen_er_0d8.yaml
+++ b/examples/input/flame_hydrogen_er_0d8.yaml
@@ -1,0 +1,13 @@
+mech: sandiego
+fuel: H2
+equiv_ratio: 0.8
+num_x: 2048
+x_max: 8.0e-2
+initial_time: 0
+final_time: 1.0e-2
+step_size: 1.0e-8
+num_snapshots: 100001
+write_freq: 100
+transport_model: mixavg
+output_dir: hydrogen_er_0d8
+filter: True

--- a/examples/input/flame_hydrogen_er_1d0.yaml
+++ b/examples/input/flame_hydrogen_er_1d0.yaml
@@ -1,0 +1,13 @@
+mech: sandiego
+fuel: H2
+equiv_ratio: 1.0
+num_x: 2048
+x_max: 8.0e-2
+initial_time: 0
+final_time: 1.0e-2
+step_size: 1.0e-8
+num_snapshots: 100001
+write_freq: 100
+transport_model: mixavg
+output_dir: hydrogen_er_1d0
+filter: True

--- a/examples/input/flame_hydrogen_er_1d2.yaml
+++ b/examples/input/flame_hydrogen_er_1d2.yaml
@@ -1,0 +1,13 @@
+mech: sandiego
+fuel: H2
+equiv_ratio: 1.2
+num_x: 2048
+x_max: 8.0e-2
+initial_time: 0
+final_time: 1.0e-2
+step_size: 1.0e-8
+num_snapshots: 100001
+write_freq: 100
+transport_model: mixavg
+output_dir: hydrogen_er_1d2
+filter: True

--- a/examples/mech/bfer.yaml
+++ b/examples/mech/bfer.yaml
@@ -1,0 +1,140 @@
+description: |-
+  CH4_BFER mechanisme: CH4 + 1.5 O2  => CO +2H2O
+                   CO + 0.5 O2 <=> CO2
+
+  Transport data from file ../transport/gri30_tran.dat.
+
+generator: cti2yaml
+cantera-version: 3.1.0
+date: Thu, 02 Oct 2025 23:08:36 -0500
+input-files: [bfer.cti]
+
+units: {length: cm, quantity: mol, activation-energy: cal/mol}
+
+phases:
+- name: gas
+  thermo: ideal-gas
+  elements: [O, H, C, N]
+  species: [C2H4, CO2, CO, O2, H2O, N2]
+  kinetics: gas
+  reactions: all
+  transport: mixture-averaged
+  state:
+    T: 300.0
+    P: 1.01325e+05
+
+species:
+- name: N2
+  composition: {N: 2}
+  thermo:
+    model: NASA7
+    temperature-ranges: [300.0, 1000.0, 5000.0]
+    data:
+    - [3.298677, 1.4082404e-03, -3.963222e-06, 5.641515e-09, -2.444854e-12,
+      -1020.8999, 3.950372]
+    - [2.92664, 1.4879768e-03, -5.68476e-07, 1.0097038e-10, -6.753351e-15,
+      -922.7977, 5.980528]
+  transport:
+    model: gas
+    geometry: linear
+    diameter: 3.621
+    well-depth: 97.53
+    polarizability: 1.76
+    rotational-relaxation: 4.0
+  note: Ref-Elm. Gurvich,1978 pt1 p280 pt2 p207. [tpis78]
+- name: O2
+  composition: {O: 2}
+  thermo:
+    model: NASA7
+    temperature-ranges: [300.0, 1000.0, 5000.0]
+    data:
+    - [3.78245636, -2.99673416e-03, 9.84730201e-06, -9.68129509e-09, 3.24372837e-12,
+      -1063.94356, 3.65767573]
+    - [3.28253784, 1.48308754e-03, -7.57966669e-07, 2.09470555e-10, -2.16717794e-14,
+      -1088.45772, 5.45323129]
+  transport:
+    model: gas
+    geometry: linear
+    diameter: 3.458
+    well-depth: 107.4
+    polarizability: 1.6
+    rotational-relaxation: 3.8
+  note: Ref-Elm. Gurvich,1989 pt1 p94 pt2 p9. [tpis89]
+- name: H2O
+  composition: {H: 2, O: 1}
+  thermo:
+    model: NASA7
+    temperature-ranges: [300.0, 1000.0, 5000.0]
+    data:
+    - [4.19864056, -2.0364341e-03, 6.52040211e-06, -5.48797062e-09, 1.77197817e-12,
+      -3.02937267e+04, -0.849032208]
+    - [3.03399249, 2.17691804e-03, -1.64072518e-07, -9.7041987e-11, 1.68200992e-14,
+      -3.00042971e+04, 4.9667701]
+  transport:
+    model: gas
+    geometry: nonlinear
+    diameter: 2.605
+    well-depth: 572.4
+    dipole: 1.844
+    rotational-relaxation: 4.0
+  note: Hf:Cox,1989. Woolley,1987. TRC(10/88) tuv25. [g 8/89]
+- name: CO
+  composition: {C: 1, O: 1}
+  thermo:
+    model: NASA7
+    temperature-ranges: [200.0, 1000.0, 3500.0]
+    data:
+    - [3.57953347, -6.1035368e-04, 1.01681433e-06, 9.07005884e-10, -9.04424499e-13,
+      -1.4344086e+04, 3.50840928]
+    - [2.71518561, 2.06252743e-03, -9.98825771e-07, 2.30053008e-10, -2.03647716e-14,
+      -1.41518724e+04, 7.81868772]
+  transport:
+    model: gas
+    geometry: linear
+    diameter: 3.65
+    well-depth: 98.1
+    polarizability: 1.95
+    rotational-relaxation: 1.8
+  note: Gurvich,1979 pt1 p25 pt2 p29. [tpis79]
+- name: CO2
+  composition: {C: 1, O: 2}
+  thermo:
+    model: NASA7
+    temperature-ranges: [200.0, 1000.0, 3500.0]
+    data:
+    - [2.35677352, 8.98459677e-03, -7.12356269e-06, 2.45919022e-09, -1.43699548e-13,
+      -4.83719697e+04, 9.90105222]
+    - [3.85746029, 4.41437026e-03, -2.21481404e-06, 5.23490188e-10, -4.72084164e-14,
+      -4.8759166e+04, 2.27163806]
+  transport:
+    model: gas
+    geometry: linear
+    diameter: 3.763
+    well-depth: 244.0
+    polarizability: 2.65
+    rotational-relaxation: 2.1
+  note: Gurvich,1991 pt1 p27 pt2 p24. [g 9/99]
+- name: C2H4
+  composition: {H: 4, C: 2}
+  thermo:
+    model: NASA7
+    temperature-ranges: [200.0, 1000.0, 3500.0]
+    data:
+    - [3.95920148, -7.57052247e-03, 5.70990292e-05, -6.91588753e-08, 2.69884373e-11,
+      5089.77593, 4.09733096]
+    - [2.03611116, 0.0146454151, -6.71077915e-06, 1.47222923e-09, -1.25706061e-13,
+      4939.88614, 10.3053693]
+  transport:
+    model: gas
+    geometry: nonlinear
+    diameter: 3.971
+    well-depth: 280.8
+    rotational-relaxation: 1.5
+  note: TRC(4/88) w2600.Chao,1975. Knippers,1985. [g 1/00]
+
+reactions:
+- equation: ' C2H4 + 2 O2 => 2 CO + 2 H2O '  # Reaction 1
+  rate-constant: {A: 1.0e+10, b: 0.0, Ea: 35500}
+  orders: {C2H4: 0.5, O2: 0.65}
+- equation: ' CO + 0.5 O2 <=> CO2'  # Reaction 2
+  rate-constant: {A: 2.0e+08, b: 0.7, Ea: 12000}

--- a/examples/mech/sandiego.yaml
+++ b/examples/mech/sandiego.yaml
@@ -1,0 +1,303 @@
+description: |-
+  nits(length='cm', time='s', quantity='mol', act_energy='kJ/mol')
+
+generator: cti2yaml
+cantera-version: 2.6.0
+date: Tue, 21 Jun 2022 15:14:08 -0500
+input-files: [sanDiego.cti]
+
+units: {length: cm, quantity: mol, activation-energy: kJ/mol}
+
+phases:
+- name: gas
+  thermo: ideal-gas
+  elements: [H, O, N]
+  species: [H2, H, O2, O, OH, HO2, H2O2, H2O, N2]
+  kinetics: gas
+  reactions: all
+  transport: mixture-averaged
+  state:
+    T: 300.0
+    P: 1.01325e+05
+
+species:
+- name: H2
+  composition: {H: 2}
+  thermo:
+    model: NASA7
+    temperature-ranges: [300.0, 1000.0, 5000.0]
+    data:
+    - [2.34433112, 7.98052075e-03, -1.9478151e-05, 2.01572094e-08, -7.37611761e-12,
+      -917.935173, 0.683010238]
+    - [3.3372792, -4.94024731e-05, 4.99456778e-07, -1.79566394e-10, 2.00255376e-14,
+      -950.158922, -3.20502331]
+  transport:
+    model: gas
+    geometry: linear
+    diameter: 2.92
+    well-depth: 38.0
+    polarizability: 0.79
+    rotational-relaxation: 280.0
+  note: '000000'
+- name: H
+  composition: {H: 1}
+  thermo:
+    model: NASA7
+    temperature-ranges: [300.0, 1000.0, 5000.0]
+    data:
+    - [2.5, 7.05332819e-13, -1.99591964e-15, 2.30081632e-18, -9.27732332e-22,
+      2.54736599e+04, -0.446682853]
+    - [2.50000001, -2.30842973e-11, 1.61561948e-14, -4.73515235e-18, 4.98197357e-22,
+      2.54736599e+04, -0.446682914]
+  transport:
+    model: gas
+    geometry: atom
+    diameter: 2.05
+    well-depth: 145.0
+  note: '000000'
+- name: O2
+  composition: {O: 2}
+  thermo:
+    model: NASA7
+    temperature-ranges: [300.0, 1000.0, 5000.0]
+    data:
+    - [3.78245636, -2.99673416e-03, 9.84730201e-06, -9.68129509e-09, 3.24372837e-12,
+      -1063.94356, 3.65767573]
+    - [3.28253784, 1.48308754e-03, -7.57966669e-07, 2.09470555e-10, -2.16717794e-14,
+      -1088.45772, 5.45323129]
+  transport:
+    model: gas
+    geometry: linear
+    diameter: 3.458
+    well-depth: 107.4
+    polarizability: 1.6
+    rotational-relaxation: 3.8
+  note: '000000'
+- name: O
+  composition: {O: 1}
+  thermo:
+    model: NASA7
+    temperature-ranges: [300.0, 1000.0, 5000.0]
+    data:
+    - [3.1682671, -3.27931884e-03, 6.64306396e-06, -6.12806624e-09, 2.11265971e-12,
+      2.91222592e+04, 2.05193346]
+    - [2.56942078, -8.59741137e-05, 4.19484589e-08, -1.00177799e-11, 1.22833691e-15,
+      2.92175791e+04, 4.78433864]
+  transport:
+    model: gas
+    geometry: atom
+    diameter: 2.75
+    well-depth: 80.0
+  note: '000000'
+- name: OH
+  composition: {H: 1, O: 1}
+  thermo:
+    model: NASA7
+    temperature-ranges: [300.0, 1000.0, 5000.0]
+    data:
+    - [4.12530561, -3.22544939e-03, 6.52764691e-06, -5.79853643e-09, 2.06237379e-12,
+      3381.53812, -0.69043296]
+    - [2.86472886, 1.05650448e-03, -2.59082758e-07, 3.05218674e-11, -1.33195876e-15,
+      3718.85774, 5.70164073]
+  transport:
+    model: gas
+    geometry: linear
+    diameter: 2.75
+    well-depth: 80.0
+  note: '000000'
+- name: HO2
+  composition: {H: 1, O: 2}
+  thermo:
+    model: NASA7
+    temperature-ranges: [300.0, 1000.0, 5000.0]
+    data:
+    - [4.30179801, -4.74912051e-03, 2.11582891e-05, -2.42763894e-08, 9.29225124e-12,
+      294.80804, 3.71666245]
+    - [4.0172109, 2.23982013e-03, -6.3365815e-07, 1.1424637e-10, -1.07908535e-14,
+      111.856713, 3.78510215]
+  transport:
+    model: gas
+    geometry: nonlinear
+    diameter: 3.458
+    well-depth: 107.4
+    rotational-relaxation: 1.0
+  note: '000000'
+- name: H2O2
+  composition: {H: 2, O: 2}
+  thermo:
+    model: NASA7
+    temperature-ranges: [300.0, 1000.0, 5000.0]
+    data:
+    - [4.27611269, -5.42822417e-04, 1.67335701e-05, -2.15770813e-08, 8.62454363e-12,
+      -1.77025821e+04, 3.43505074]
+    - [4.16500285, 4.90831694e-03, -1.90139225e-06, 3.71185986e-10, -2.87908305e-14,
+      -1.78617877e+04, 2.91615662]
+  transport:
+    model: gas
+    geometry: nonlinear
+    diameter: 3.458
+    well-depth: 107.4
+    rotational-relaxation: 3.8
+  note: '000000'
+- name: H2O
+  composition: {H: 2, O: 1}
+  thermo:
+    model: NASA7
+    temperature-ranges: [300.0, 1000.0, 5000.0]
+    data:
+    - [4.19864056, -2.0364341e-03, 6.52040211e-06, -5.48797062e-09, 1.77197817e-12,
+      -3.02937267e+04, -0.849032208]
+    - [3.03399249, 2.17691804e-03, -1.64072518e-07, -9.7041987e-11, 1.68200992e-14,
+      -3.00042971e+04, 4.9667701]
+  transport:
+    model: gas
+    geometry: nonlinear
+    diameter: 2.605
+    well-depth: 572.4
+    dipole: 1.844
+    rotational-relaxation: 4.0
+  note: '000000'
+- name: CO
+  composition: {C: 1, O: 1}
+  thermo:
+    model: NASA7
+    temperature-ranges: [300.0, 1000.0, 5000.0]
+    data:
+    - [3.57953347, -6.1035368e-04, 1.01681433e-06, 9.07005884e-10, -9.04424499e-13,
+      -1.4344086e+04, 3.50840928]
+    - [2.71518561, 2.06252743e-03, -9.98825771e-07, 2.30053008e-10, -2.03647716e-14,
+      -1.41518724e+04, 7.81868772]
+  transport:
+    model: gas
+    geometry: linear
+    diameter: 3.65
+    well-depth: 98.1
+    polarizability: 1.95
+    rotational-relaxation: 1.8
+  note: '000000'
+- name: CO2
+  composition: {C: 1, O: 2}
+  thermo:
+    model: NASA7
+    temperature-ranges: [300.0, 1000.0, 5000.0]
+    data:
+    - [2.35677352, 8.98459677e-03, -7.12356269e-06, 2.45919022e-09, -1.43699548e-13,
+      -4.83719697e+04, 9.90105222]
+    - [3.85746029, 4.41437026e-03, -2.21481404e-06, 5.23490188e-10, -4.72084164e-14,
+      -4.8759166e+04, 2.27163806]
+  transport:
+    model: gas
+    geometry: linear
+    diameter: 3.763
+    well-depth: 244.0
+    polarizability: 2.65
+    rotational-relaxation: 2.1
+  note: '000000'
+- name: HCO
+  composition: {H: 1, C: 1, O: 1}
+  thermo:
+    model: NASA7
+    temperature-ranges: [300.0, 1000.0, 5000.0]
+    data:
+    - [4.22118584, -3.24392532e-03, 1.37799446e-05, -1.33144093e-08, 4.33768865e-12,
+      3839.56496, 3.39437243]
+    - [2.77217438, 4.95695526e-03, -2.48445613e-06, 5.89161778e-10, -5.33508711e-14,
+      4011.91815, 9.79834492]
+  transport:
+    model: gas
+    geometry: nonlinear
+    diameter: 3.59
+    well-depth: 498.0
+  note: '000000'
+- name: N2
+  composition: {N: 2}
+  thermo:
+    model: NASA7
+    temperature-ranges: [300.0, 1000.0, 5000.0]
+    data:
+    - [3.298677, 1.4082404e-03, -3.963222e-06, 5.641515e-09, -2.444854e-12,
+      -1020.8999, 3.950372]
+    - [2.92664, 1.4879768e-03, -5.68476e-07, 1.0097038e-10, -6.753351e-15,
+      -922.7977, 5.980528]
+  transport:
+    model: gas
+    geometry: linear
+    diameter: 3.621
+    well-depth: 97.53
+    polarizability: 1.76
+    rotational-relaxation: 4.0
+  note: '000000'
+
+reactions:
+- equation: H + O2 <=> OH + O  # Reaction 1
+  rate-constant: {A: 3.52e+16, b: -0.7, Ea: 71.42}
+- equation: H2 + O <=> OH + H  # Reaction 2
+  rate-constant: {A: 5.06e+04, b: 2.67, Ea: 26.32}
+- equation: H2 + OH <=> H2O + H  # Reaction 3
+  rate-constant: {A: 1.17e+09, b: 1.3, Ea: 15.21}
+- equation: H2O + O <=> 2 OH  # Reaction 4
+  rate-constant: {A: 7.0e+05, b: 2.33, Ea: 60.87}
+- equation: H + H + M <=> H2 + M  # Reaction 5
+  type: three-body
+  rate-constant: {A: 1.3e+18, b: -1.0, Ea: 0.0}
+  efficiencies: {H2: 2.5, H2O: 12.0}
+- equation: H + OH + M <=> H2O + M  # Reaction 6
+  type: three-body
+  rate-constant: {A: 4.0e+22, b: -2.0, Ea: 0.0}
+  efficiencies: {H2: 2.5, H2O: 12.0}
+- equation: O + O + M <=> O2 + M  # Reaction 7
+  type: three-body
+  rate-constant: {A: 6.17e+15, b: -0.5, Ea: 0.0}
+  efficiencies: {H2: 2.5, H2O: 12.0}
+- equation: H + O + M <=> OH + M  # Reaction 8
+  type: three-body
+  rate-constant: {A: 4.71e+18, b: -1.0, Ea: 0.0}
+  efficiencies: {H2: 2.5, H2O: 12.0}
+- equation: O + OH + M <=> HO2 + M  # Reaction 9
+  type: three-body
+  rate-constant: {A: 8.0e+15, b: 0.0, Ea: 0.0}
+  efficiencies: {H2: 2.5, H2O: 12.0}
+- equation: H + O2 (+ M) <=> HO2 (+ M)  # Reaction 10
+  type: falloff
+  low-P-rate-constant: {A: 5.75e+19, b: -1.4, Ea: 0.0}
+  high-P-rate-constant: {A: 4.65e+12, b: 0.44, Ea: 0.0}
+  Troe: {A: 0.5, T3: 1.0e-30, T1: 1.0e+30}
+  efficiencies: {H2: 2.5, H2O: 16.0}
+- equation: HO2 + H <=> 2 OH  # Reaction 11
+  rate-constant: {A: 7.08e+13, b: 0.0, Ea: 1.234}
+- equation: HO2 + H <=> H2 + O2  # Reaction 12
+  rate-constant: {A: 1.66e+13, b: 0.0, Ea: 3.443}
+- equation: HO2 + H <=> H2O + O  # Reaction 13
+  rate-constant: {A: 3.1e+13, b: 0.0, Ea: 7.2}
+- equation: HO2 + O <=> OH + O2  # Reaction 14
+  rate-constant: {A: 2.0e+13, b: 0.0, Ea: 0.0}
+- equation: HO2 + OH <=> H2O + O2  # Reaction 15
+  rate-constant: {A: 4.5e+14, b: 0.0, Ea: 45.73}
+  duplicate: true
+- equation: HO2 + OH <=> H2O + O2  # Reaction 16
+  rate-constant: {A: 2.98e+13, b: 0.0, Ea: -2.08}
+  duplicate: true
+- equation: OH + OH (+ M) <=> H2O2 (+ M)  # Reaction 17
+  type: falloff
+  low-P-rate-constant: {A: 2.76e+25, b: -3.2, Ea: 0.0}
+  high-P-rate-constant: {A: 9.55e+13, b: -0.27, Ea: 0.0}
+  Troe: {A: 0.57, T3: 1.0e+30, T1: 1.0e-30}
+  efficiencies: {H2: 2.5, H2O: 6.0}
+- equation: HO2 + HO2 <=> H2O2 + O2  # Reaction 18
+  rate-constant: {A: 1.94e+11, b: 0.0, Ea: -5.895}
+  duplicate: true
+- equation: HO2 + HO2 <=> H2O2 + O2  # Reaction 19
+  rate-constant: {A: 1.03e+14, b: 0.0, Ea: 46.2}
+  duplicate: true
+- equation: H2O2 + H <=> HO2 + H2  # Reaction 20
+  rate-constant: {A: 2.3e+13, b: 0.0, Ea: 33.263}
+- equation: H2O2 + H <=> H2O + OH  # Reaction 21
+  rate-constant: {A: 1.0e+13, b: 0.0, Ea: 15.0}
+- equation: H2O2 + OH <=> H2O + HO2  # Reaction 22
+  rate-constant: {A: 7.59e+13, b: 0.0, Ea: 30.43}
+  duplicate: true
+- equation: H2O2 + OH <=> H2O + HO2  # Reaction 23
+  rate-constant: {A: 1.74e+12, b: 0.0, Ea: 1.33}
+  duplicate: true
+- equation: H2O2 + O <=> HO2 + OH  # Reaction 24
+  rate-constant: {A: 9.63e+06, b: 2.0, Ea: 16.7}

--- a/examples/profiling.py
+++ b/examples/profiling.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+from dataclasses import dataclass, field
+from collections import defaultdict
+import time
+from typing import Dict, Optional, Callable
+from contextlib import contextmanager
+
+@dataclass
+class SerialTimer:
+    """
+    Minimal high-resolution timer for a single-process NumPy codebase.
+    Usage:
+        T = SerialTimer()
+        t0 = T.start()
+        # ... work ...
+        T.record('rhs_eval', T.stop(t0))
+        T.report(total='outer_time_loop')  # optional: set which key is 'total'
+    """
+    sums: Dict[str, float] = field(default_factory=lambda: defaultdict(float))
+    calls: Dict[str, int]   = field(default_factory=lambda: defaultdict(int))
+
+    # --- basic API ---
+    def start(self) -> float:
+        return time.perf_counter()
+
+    def stop(self, t0: float) -> float:
+        return time.perf_counter() - t0
+
+    def record(self, name: str, dt: float) -> None:
+        self.sums[name]  += dt
+        self.calls[name] += 1
+
+    # --- convenience: context manager ---
+    @contextmanager
+    def timeit(self, name: str):
+        t0 = self.start()
+        try:
+            yield
+        finally:
+            self.record(name, self.stop(t0))
+
+    # --- convenience: decorator ---
+    def wrap(self, name: str) -> Callable:
+        def _decorator(fn: Callable) -> Callable:
+            def _wrapped(*args, **kwargs):
+                t0 = self.start()
+                try:
+                    return fn(*args, **kwargs)
+                finally:
+                    self.record(name, self.stop(t0))
+            return _wrapped
+        return _decorator
+
+    # --- reporting ---
+    def report(self, total: Optional[str] = None, sort_by: str = "time") -> None:
+        """
+        Print a table of timings.
+        total: if provided, percentages are computed vs sums[total]; otherwise vs sum of all.
+        sort_by: 'time' (default) or 'name'.
+        """
+        rows = []
+        grand_total = self.sums.get(total, None)
+        if grand_total is None:
+            grand_total = sum(self.sums.values()) or 1.0
+
+        for k in self.sums:
+            avg = self.sums[k] / max(self.calls[k], 1)
+            pct = 100.0 * (self.sums[k] / grand_total if grand_total > 0 else 0.0)
+            rows.append((k, self.calls[k], self.sums[k], avg, pct))
+
+        if sort_by == "name":
+            rows.sort(key=lambda r: r[0])
+        else:
+            rows.sort(key=lambda r: r[2], reverse=True)
+
+        print("\n=== Serial Timings ===")
+        print(f"{'name':26s} {'calls':>6s} {'total(s)':>10s} {'avg(s)':>10s} {'%':>7s}")
+        for k, c, tot, avg, pct in rows:
+            print(f"{k:26s} {c:6d} {tot:10.6f} {avg:10.6f} {pct:7.1f}")
+        print(f"(Reference total: '{total}' = {grand_total:.6f} s)" if total else
+              f"(Reference total: sum of rows = {grand_total:.6f} s)")
+
+    # --- utilities ---
+    def reset(self) -> None:
+        self.sums.clear()
+        self.calls.clear()

--- a/pyrometheus/chem_expr.py
+++ b/pyrometheus/chem_expr.py
@@ -367,7 +367,7 @@ def troe_falloff_center_expr(react: ct.Reaction, t):
         troe_3 = p.Variable("exp")(-troe_params[3]/t)
         return p.Variable("log10")(troe_1 + troe_2 + troe_3)
     else:
-        raise ValueError("Unexpected length of 'tro_params': "
+        raise ValueError("Unexpected length of 'troe_params': "
                          f" '{len(troe_params)}'")
     return
 

--- a/pyrometheus/codegen/python.py
+++ b/pyrometheus/codegen/python.py
@@ -422,14 +422,14 @@ class Thermochemistry:
 
         falloff_center = self._pyro_make_array([
         %for _, react in falloff_reactions:
-            ${cgm(ce.troe_falloff_center_expr(react,Variable("temperature")))},
+            ${cgm(ce.troe_falloff_center_expr(react,Variable("temperature")))} * ones,
         %endfor
         ])
 
         falloff_factor = self._pyro_make_array([
         %for i, (_, react) in enumerate(falloff_reactions):
             ${cgm(ce.troe_falloff_factor_expr(react, i,
-            Variable("reduced_pressure"), Variable("falloff_center")))},
+            Variable("reduced_pressure"), Variable("falloff_center")))} * ones,
         %endfor
         ])
 
@@ -438,7 +438,7 @@ class Thermochemistry:
             ${cgm(ce.falloff_function_expr(
                 react, i,
                 Variable("falloff_factor"),
-                Variable("falloff_center")))},
+                Variable("falloff_center")))} * ones,
         %endfor
         ])*reduced_pressure/(1+reduced_pressure)
 

--- a/test/mechs/bfer.yaml
+++ b/test/mechs/bfer.yaml
@@ -1,0 +1,140 @@
+description: |-
+  CH4_BFER mechanisme: CH4 + 1.5 O2  => CO +2H2O
+                   CO + 0.5 O2 <=> CO2
+
+  Transport data from file ../transport/gri30_tran.dat.
+
+generator: cti2yaml
+cantera-version: 3.1.0
+date: Thu, 02 Oct 2025 23:08:36 -0500
+input-files: [bfer.cti]
+
+units: {length: cm, quantity: mol, activation-energy: cal/mol}
+
+phases:
+- name: gas
+  thermo: ideal-gas
+  elements: [O, H, C, N]
+  species: [C2H4, CO2, CO, O2, H2O, N2]
+  kinetics: gas
+  reactions: all
+  transport: mixture-averaged
+  state:
+    T: 300.0
+    P: 1.01325e+05
+
+species:
+- name: N2
+  composition: {N: 2}
+  thermo:
+    model: NASA7
+    temperature-ranges: [300.0, 1000.0, 5000.0]
+    data:
+    - [3.298677, 1.4082404e-03, -3.963222e-06, 5.641515e-09, -2.444854e-12,
+      -1020.8999, 3.950372]
+    - [2.92664, 1.4879768e-03, -5.68476e-07, 1.0097038e-10, -6.753351e-15,
+      -922.7977, 5.980528]
+  transport:
+    model: gas
+    geometry: linear
+    diameter: 3.621
+    well-depth: 97.53
+    polarizability: 1.76
+    rotational-relaxation: 4.0
+  note: Ref-Elm. Gurvich,1978 pt1 p280 pt2 p207. [tpis78]
+- name: O2
+  composition: {O: 2}
+  thermo:
+    model: NASA7
+    temperature-ranges: [300.0, 1000.0, 5000.0]
+    data:
+    - [3.78245636, -2.99673416e-03, 9.84730201e-06, -9.68129509e-09, 3.24372837e-12,
+      -1063.94356, 3.65767573]
+    - [3.28253784, 1.48308754e-03, -7.57966669e-07, 2.09470555e-10, -2.16717794e-14,
+      -1088.45772, 5.45323129]
+  transport:
+    model: gas
+    geometry: linear
+    diameter: 3.458
+    well-depth: 107.4
+    polarizability: 1.6
+    rotational-relaxation: 3.8
+  note: Ref-Elm. Gurvich,1989 pt1 p94 pt2 p9. [tpis89]
+- name: H2O
+  composition: {H: 2, O: 1}
+  thermo:
+    model: NASA7
+    temperature-ranges: [300.0, 1000.0, 5000.0]
+    data:
+    - [4.19864056, -2.0364341e-03, 6.52040211e-06, -5.48797062e-09, 1.77197817e-12,
+      -3.02937267e+04, -0.849032208]
+    - [3.03399249, 2.17691804e-03, -1.64072518e-07, -9.7041987e-11, 1.68200992e-14,
+      -3.00042971e+04, 4.9667701]
+  transport:
+    model: gas
+    geometry: nonlinear
+    diameter: 2.605
+    well-depth: 572.4
+    dipole: 1.844
+    rotational-relaxation: 4.0
+  note: Hf:Cox,1989. Woolley,1987. TRC(10/88) tuv25. [g 8/89]
+- name: CO
+  composition: {C: 1, O: 1}
+  thermo:
+    model: NASA7
+    temperature-ranges: [200.0, 1000.0, 3500.0]
+    data:
+    - [3.57953347, -6.1035368e-04, 1.01681433e-06, 9.07005884e-10, -9.04424499e-13,
+      -1.4344086e+04, 3.50840928]
+    - [2.71518561, 2.06252743e-03, -9.98825771e-07, 2.30053008e-10, -2.03647716e-14,
+      -1.41518724e+04, 7.81868772]
+  transport:
+    model: gas
+    geometry: linear
+    diameter: 3.65
+    well-depth: 98.1
+    polarizability: 1.95
+    rotational-relaxation: 1.8
+  note: Gurvich,1979 pt1 p25 pt2 p29. [tpis79]
+- name: CO2
+  composition: {C: 1, O: 2}
+  thermo:
+    model: NASA7
+    temperature-ranges: [200.0, 1000.0, 3500.0]
+    data:
+    - [2.35677352, 8.98459677e-03, -7.12356269e-06, 2.45919022e-09, -1.43699548e-13,
+      -4.83719697e+04, 9.90105222]
+    - [3.85746029, 4.41437026e-03, -2.21481404e-06, 5.23490188e-10, -4.72084164e-14,
+      -4.8759166e+04, 2.27163806]
+  transport:
+    model: gas
+    geometry: linear
+    diameter: 3.763
+    well-depth: 244.0
+    polarizability: 2.65
+    rotational-relaxation: 2.1
+  note: Gurvich,1991 pt1 p27 pt2 p24. [g 9/99]
+- name: C2H4
+  composition: {H: 4, C: 2}
+  thermo:
+    model: NASA7
+    temperature-ranges: [200.0, 1000.0, 3500.0]
+    data:
+    - [3.95920148, -7.57052247e-03, 5.70990292e-05, -6.91588753e-08, 2.69884373e-11,
+      5089.77593, 4.09733096]
+    - [2.03611116, 0.0146454151, -6.71077915e-06, 1.47222923e-09, -1.25706061e-13,
+      4939.88614, 10.3053693]
+  transport:
+    model: gas
+    geometry: nonlinear
+    diameter: 3.971
+    well-depth: 280.8
+    rotational-relaxation: 1.5
+  note: TRC(4/88) w2600.Chao,1975. Knippers,1985. [g 1/00]
+
+reactions:
+- equation: ' C2H4 + 2 O2 => 2 CO + 2 H2O '  # Reaction 1
+  rate-constant: {A: 1.0e+10, b: 0.0, Ea: 35500}
+  orders: {C2H4: 0.5, O2: 0.65}
+- equation: ' CO + 0.5 O2 <=> CO2'  # Reaction 2
+  rate-constant: {A: 2.0e+08, b: 0.7, Ea: 12000}


### PR DESCRIPTION
This PR updates the scripts to run laminar flames using the generated code. Input files for hydrogen- and ethylene-air are provided. A new post-processing script that calculates the flame speed is included. 