### PR TITLE
Fix Cray Fortran OpenACC codegen: emit !$acc routine seq instead of !DIR$ INLINEALWAYS

### DIFF
--- a/pyrometheus/codegen/fortran.py
+++ b/pyrometheus/codegen/fortran.py
@@ -922,11 +922,7 @@ class FortranCodeGenerator(CodeGenerator):
 
         if opts.directive_offload == "acc":
             gpu_routine_str = """
-#ifdef _CRAYFTN
-#define GPU_ROUTINE(name) !DIR$ INLINEALWAYS name
-#else
 #define GPU_ROUTINE(name) !$acc routine seq
-#endif
 """
         elif opts.directive_offload == "mp":
             gpu_routine_str = """


### PR DESCRIPTION
## Summary

The `_CRAYFTN` branch of the `GPU_ROUTINE` macro in the Fortran code generator emits `!DIR$ INLINEALWAYS` instead of `!$acc routine seq` when `directive_offload == "acc"`. This is an inlining hint, not a device routine declaration, so thermochem routines are never registered as OpenACC device routines on Cray compilers (e.g., CCE 19 on Frontier).

**Before (broken on Cray):**
```fortran
#ifdef _CRAYFTN
#define GPU_ROUTINE(name) !DIR$ INLINEALWAYS name
#else
#define GPU_ROUTINE(name) !$acc routine seq
#endif
```

**After (works on all compilers):**
```fortran
#define GPU_ROUTINE(name) !$acc routine seq
```

When `directive_offload == "acc"`, the intent is always to generate OpenACC device routines. `!$acc routine seq` is the correct directive for all compilers, including Cray. The `!DIR$ INLINEALWAYS` directive is a Cray-specific inlining hint that does not register the routine for GPU execution.

This bug was discovered and worked around downstream in [MFC](https://github.com/MFlowCode/MFC) (see [MFC PR #1336](https://github.com/MFlowCode/MFC/pull/1336)), where the generated code is post-processed to replace the broken macro. This fix eliminates the need for that workaround.

## Test plan
- Verified that MFC chemistry tests pass on Frontier (Cray CCE 19 + OpenACC) with this change applied
- Non-Cray compilers (nvfortran, gfortran) are unaffected since they already received `!$acc routine seq`