### PR TITLE
Restore Python 3.8 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         name: Pytest Conda Py${{ matrix.python-version }}
         strategy:
             matrix:
-                python-version: ["3.9", "3.11", "3.12", "3.13", "3.14"]
+                python-version: ["3.8", "3.9", "3.11", "3.12", "3.13", "3.14"]
         runs-on: ubuntu-latest
         env:
             PYTHON_VERSION: ${{ matrix.python-version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
   { name="Henry Le Berre",    email="hberre3@gatech.edu"   },
 ]
 description = "Code generation for combustion thermochemistry, based on Cantera."
-requires-python = ">=3.9"
+requires-python = ">=3.8"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Programming Language :: Python :: 3",
@@ -61,8 +61,8 @@ dev  = [
     "Flake8-pyproject",
 ]
 test = [
-    "jax",
-    "jaxlib",
+    "jax; python_version >= '3.9'",
+    "jaxlib; python_version >= '3.9'",
     "pytest",
     "pybind11",
 ]


### PR DESCRIPTION
This lowers the package metadata back to Python 3.8 and includes Python 3.8 in the pytest CI matrix.

The core package and existing tests already tolerate JAX being unavailable, so this also gates the optional JAX test dependencies to Python >= 3.9. That keeps `.[test]` installable on Python 3.8 while preserving the existing JAX coverage on newer Python versions.

Local checks run:
- `uv pip install --python /tmp/pyrometheus-py38-venv/bin/python -e .[test]`
- `/tmp/pyrometheus-py38-venv/bin/python -m compileall -q pyrometheus test`
- `/tmp/pyrometheus-py38-venv/bin/python -m pyrometheus --version`
- `/tmp/pyrometheus-py38-venv/bin/python -m pyrometheus --language fortran --mechanism test/mechs/sandiego.yaml --name thermochem --output /tmp/pyro38_thermochem.f90 --phase gas`
- Python-backend CMake/CTest with `-DTEST_cpp=OFF -DTEST_fortran=OFF -DPython3_EXECUTABLE=/tmp/pyrometheus-py38-venv/bin/python`