### PR TITLE
Prepare 1.0.7 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name    = "pyrometheus"
-version = "1.0.6"
+version = "1.0.7"
 readme  = "README.rst"
 authors = [
   { name="Esteban Cisneros",  email="ecisnerosg88@gmail.com" },


### PR DESCRIPTION
Prepares a 1.0.7 patch release from current main. This includes the already-merged Python 3.9 metadata and importlib.metadata CLI version lookup, which lets downstream package managers consume the PyPI sdist without carrying a pkg_resources compatibility patch.\n\nLocal checks run:\n- python -m build\n- twine check dist/*\n- installed the wheel in a clean Python 3.11 virtualenv\n- python -m pyrometheus --version\n- generated Fortran code from h2o2.yaml