### PR TITLE
Spack support: install instructions and CI

### DIFF
--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -12,32 +12,13 @@ jobs:
         steps:
           - uses: actions/checkout@v4
 
-          - name: Check out Spack
-            uses: actions/checkout@v4
+          - name: Set up Spack with buildcache
+            uses: spack/setup-spack@v3
             with:
-                repository: spack/spack
-                path: spack
-
-          - name: Check out spack-packages
-            uses: actions/checkout@v4
-            with:
-                repository: spack/spack-packages
-                path: spack-packages
-
-          - name: Cache Spack store
-            uses: actions/cache@v4
-            with:
-                path: |
-                    spack/opt
-                    spack/var/spack/cache
-                key: spack-released-${{ runner.os }}-${{ hashFiles('spack-packages/repos/spack_repo/builtin/packages/py_pyrometheus/package.py', 'spack-packages/repos/spack_repo/builtin/packages/cantera/package.py') }}
-                restore-keys: spack-released-${{ runner.os }}-
+                buildcache: true
 
           - name: Install py-pyrometheus
-            run: |
-                source spack/share/spack/setup-env.sh
-                spack repo add --scope=site spack-packages/repos/spack_repo/builtin
-                spack install --reuse py-pyrometheus
+            run: spack install --reuse py-pyrometheus
 
           - name: Smoke test
             run: |
@@ -55,31 +36,14 @@ jobs:
         steps:
           - uses: actions/checkout@v4
 
-          - name: Check out Spack
-            uses: actions/checkout@v4
+          - name: Set up Spack with buildcache
+            uses: spack/setup-spack@v3
             with:
-                repository: spack/spack
-                path: spack
-
-          - name: Check out spack-packages
-            uses: actions/checkout@v4
-            with:
-                repository: spack/spack-packages
-                path: spack-packages
-
-          - name: Cache Spack store
-            uses: actions/cache@v4
-            with:
-                path: |
-                    spack/opt
-                    spack/var/spack/cache
-                key: spack-head-${{ runner.os }}-${{ hashFiles('spack-packages/repos/spack_repo/builtin/packages/py_pyrometheus/package.py', 'spack-packages/repos/spack_repo/builtin/packages/cantera/package.py') }}
-                restore-keys: spack-head-${{ runner.os }}-
+                buildcache: true
 
           - name: Install pyrometheus HEAD against spack deps
             run: |
                 source spack/share/spack/setup-env.sh
-                spack repo add --scope=site spack-packages/repos/spack_repo/builtin
                 spack env create dev
                 spack env activate dev
                 spack add py-pyrometheus@main

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -1,0 +1,97 @@
+name: Spack
+on:
+    push:
+    pull_request:
+    schedule:
+        - cron: '17 3 * * 0'
+
+jobs:
+    spack-released:
+        name: Spack install released
+        runs-on: ubuntu-latest
+        steps:
+          - uses: actions/checkout@v4
+
+          - name: Check out Spack
+            uses: actions/checkout@v4
+            with:
+                repository: spack/spack
+                path: spack
+
+          - name: Check out spack-packages
+            uses: actions/checkout@v4
+            with:
+                repository: spack/spack-packages
+                path: spack-packages
+
+          - name: Cache Spack store
+            uses: actions/cache@v4
+            with:
+                path: |
+                    spack/opt
+                    spack/var/spack/cache
+                key: spack-released-${{ runner.os }}-${{ hashFiles('spack-packages/repos/spack_repo/builtin/packages/py_pyrometheus/package.py', 'spack-packages/repos/spack_repo/builtin/packages/cantera/package.py') }}
+                restore-keys: spack-released-${{ runner.os }}-
+
+          - name: Install py-pyrometheus
+            run: |
+                source spack/share/spack/setup-env.sh
+                spack repo add --scope=site spack-packages/repos/spack_repo/builtin
+                spack install --reuse py-pyrometheus
+
+          - name: Smoke test
+            run: |
+                source spack/share/spack/setup-env.sh
+                spack load py-pyrometheus
+                python3 -c "import pyrometheus; print('imported OK')"
+                python3 -m pyrometheus --version
+                python3 -m pyrometheus -l fortran -m test/mechs/sandiego.yaml \
+                                       -o spack_test_thermo.f90 -n thermo -p gas
+                test -s spack_test_thermo.f90
+
+    spack-head:
+        name: Spack install HEAD
+        runs-on: ubuntu-latest
+        steps:
+          - uses: actions/checkout@v4
+
+          - name: Check out Spack
+            uses: actions/checkout@v4
+            with:
+                repository: spack/spack
+                path: spack
+
+          - name: Check out spack-packages
+            uses: actions/checkout@v4
+            with:
+                repository: spack/spack-packages
+                path: spack-packages
+
+          - name: Cache Spack store
+            uses: actions/cache@v4
+            with:
+                path: |
+                    spack/opt
+                    spack/var/spack/cache
+                key: spack-head-${{ runner.os }}-${{ hashFiles('spack-packages/repos/spack_repo/builtin/packages/py_pyrometheus/package.py', 'spack-packages/repos/spack_repo/builtin/packages/cantera/package.py') }}
+                restore-keys: spack-head-${{ runner.os }}-
+
+          - name: Install pyrometheus HEAD against spack deps
+            run: |
+                source spack/share/spack/setup-env.sh
+                spack repo add --scope=site spack-packages/repos/spack_repo/builtin
+                spack env create dev
+                spack env activate dev
+                spack add py-pyrometheus@1.0.7
+                spack develop --path "$GITHUB_WORKSPACE" py-pyrometheus@1.0.7
+                spack install --reuse
+
+          - name: Smoke test
+            run: |
+                source spack/share/spack/setup-env.sh
+                spack env activate dev
+                python3 -c "import pyrometheus; print('imported OK')"
+                python3 -m pyrometheus --version
+                python3 -m pyrometheus -l fortran -m test/mechs/sandiego.yaml \
+                                       -o spack_test_thermo.f90 -n thermo -p gas
+                test -s spack_test_thermo.f90

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -82,8 +82,8 @@ jobs:
                 spack repo add --scope=site spack-packages/repos/spack_repo/builtin
                 spack env create dev
                 spack env activate dev
-                spack add py-pyrometheus@1.0.7
-                spack develop --path "$GITHUB_WORKSPACE" py-pyrometheus@1.0.7
+                spack add py-pyrometheus@main
+                spack develop --path "$GITHUB_WORKSPACE" py-pyrometheus@main
                 spack install --reuse
 
           - name: Smoke test

--- a/README.rst
+++ b/README.rst
@@ -21,6 +21,9 @@ Pyrometheus: Code Generation for Combustion Mechanisms
 .. image:: https://img.shields.io/badge/arXiv-2503.24286-b31b1b.svg
    :target: https://arxiv.org/abs/2503.24286
    :alt: arXiv:2503.24286
+.. image:: https://img.shields.io/badge/DOI-10.1016%2Fj.cpc.2025.109987-blue.svg
+   :target: https://doi.org/10.1016/j.cpc.2025.109987
+   :alt: DOI:10.1016/j.cpc.2025.109987
 
 .. When you update this description, consider also updating the one in doc/index.rst.
 
@@ -52,7 +55,7 @@ Cite me:
 
 .. code-block:: bibtex
 
-    @article{cisneros25,
+    @article{Cisneros25,
       author = {Cisneros-Garibay, Esteban and {Le Berre}, H. and Adam, D. and Bryngelson, Spencer H. and Freund, Jonathan B.},
       title = {{Pyrometheus: S}ymbolic abstractions for {XPU} and automatically differentiated computation of combustion kinetics and thermodynamics},
       year = {2026},

--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,8 @@ Pyrometheus: Code Generation for Combustion Mechanisms
 .. When you update this description, consider also updating the one in doc/index.rst.
 
 Pyrometheus is a code generator for chemical mechanisms based on `Cantera
-<https://cantera.org>`__::
+<https://cantera.org>`__. Install it from PyPI (``pip install pyrometheus``)
+or via `Spack <https://spack.io>`__ (``spack install py-pyrometheus``)::
 
     $ python3 -m pip install pyrometheus
     $ python3 -m pyrometheus --help

--- a/doc/start.rst
+++ b/doc/start.rst
@@ -8,6 +8,16 @@ You can obtain Pyrometheus from the Python Package Index (PyPI) by running::
 
     python3 -m pip install pyrometheus
 
+Alternatively, Pyrometheus is available through `Spack
+<https://spack.io>`__::
+
+    spack install py-pyrometheus
+
+This installs Pyrometheus together with its runtime dependencies
+(Cantera, Mako, pymbolic). The package was added to spack-packages in
+`#4696 <https://github.com/spack/spack-packages/pull/4696>`__ and
+tracks ``pyrometheus`` releases on PyPI.
+
 Test
 ----
 


### PR DESCRIPTION
Adds Spack as a supported install path for Pyrometheus and wires up CI to keep that path tested.

## Changes

- **`doc/start.rst`**: documents `spack install py-pyrometheus` alongside the existing `pip install` instructions, with a pointer to [spack-packages#4696](https://github.com/spack/spack-packages/pull/4696) (the recipe).
- **`README.rst`**: one-line mention of the Spack install command in the header blurb.
- **`.github/workflows/spack.yml`**: new `Spack` workflow with two jobs on `ubuntu-latest`:
  - `Spack install released` — `spack install py-pyrometheus` (PyPI tarball), then imports, runs `pyrometheus --version`, and generates Fortran code from `test/mechs/sandiego.yaml`.
  - `Spack install HEAD` — uses `spack develop` to install the current checkout against the spack recipe's declared dependency graph, then runs the same smoke test. Catches breakages where pyrometheus' deps drift from the spack recipe.

Both jobs aggressively cache `spack/opt` and `spack/var/spack/cache` so subsequent runs reuse the Cantera build (cold ~1.5h on a 2-core runner; warm should be minutes).

## Verification

Both jobs were run on a fork branch and passed end-to-end (full Cantera build → pyrometheus install → import → CLI → Fortran codegen):
- https://github.com/sbryngelson/pyrometheus/actions/runs/25974420501

## Follow-up

The `Spack install HEAD` job currently pins `py-pyrometheus@1.0.7` because that's the only version the spack recipe declares. [spack-packages#4875](https://github.com/spack/spack-packages/pull/4875) adds `version("main", branch="main")` to the recipe; once that merges I'll push a small follow-up here switching the HEAD job to `@main` so it stops needing per-release bumps.