### PR TITLE
Fix scheduled Spack CI: pin Spack refs and bump checkout to v5

### DIFF
--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -10,7 +10,7 @@ jobs:
         name: Spack install released
         runs-on: ubuntu-latest
         steps:
-          - uses: actions/checkout@v4
+          - uses: actions/checkout@v5
 
           - name: Set up Spack with buildcache
             uses: spack/setup-spack@v3
@@ -36,7 +36,7 @@ jobs:
         name: Spack install HEAD
         runs-on: ubuntu-latest
         steps:
-          - uses: actions/checkout@v4
+          - uses: actions/checkout@v5
 
           - name: Set up Spack with buildcache
             uses: spack/setup-spack@v3

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -15,6 +15,8 @@ jobs:
           - name: Set up Spack with buildcache
             uses: spack/setup-spack@v3
             with:
+                spack_ref: releases/v1.2
+                packages_ref: releases/v2026.06
                 buildcache: true
 
           - name: Install py-pyrometheus
@@ -39,6 +41,8 @@ jobs:
           - name: Set up Spack with buildcache
             uses: spack/setup-spack@v3
             with:
+                spack_ref: releases/v1.2
+                packages_ref: releases/v2026.06
                 buildcache: true
 
           - name: Install pyrometheus HEAD against spack deps


### PR DESCRIPTION
## Problem

The weekly scheduled `Spack` workflow flipped from passing (2026-06-21) to failing (2026-06-28+) with no change to `main`. Root cause: `spack/setup-spack@v3` defaults both `spack_ref` and `packages_ref` to `develop`, so every run concretized against bleeding-edge Spack. That week `develop` selected brand-new versions (`cantera@3.2.0`, `readline@8.3`, `python@3.14`) with no matching binaries in the build cache, forcing source builds that hit a Cantera `-lintl` link error and an unmirrored readline patch (404).

## Fix

- Pin `spack_ref: releases/v1.2` and `packages_ref: releases/v2026.06` in both jobs (`v2026.06` is the first packages release containing the `py_pyrometheus` recipe). Installs are now deterministic and backed by the populated build cache.
- Bump `actions/checkout@v4` → `@v5` to run on Node 24, clearing the Node.js 20 deprecation warning.

## Verification

CI run [`29036299047`](https://github.com/pyrometheus/pyrometheus/actions/runs/29036299047) is green — both `Spack install released` and `Spack install HEAD` pass, and the Node 20 deprecation warning is gone.

## Maintenance note

Versions are now pinned deliberately, so the pins will need a periodic bump as those Spack releases age out — this trades surprise breakage from upstream `develop` for controlled updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)