### PR TITLE
Bump version to 1.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name    = "pyrometheus"
-version = "1.1.0"
+version = "1.1.1"
 readme  = "README.rst"
 authors = [
   { name="Esteban Cisneros",  email="ecisnerosg88@gmail.com" },


### PR DESCRIPTION
Patch release so the `get_creation_destruction_rates` routine (single-pass creation+destruction, added in #116) reaches PyPI. `main` still declares 1.1.0, which is already published without that routine, so a bump is required before downstream consumers (MFC) can pin to a released version instead of tracking git HEAD.